### PR TITLE
Fix Markdown issue in 0.15 blog post

### DIFF
--- a/_posts/2015-02-21-eslint-0.15.0-released.md
+++ b/_posts/2015-02-21-eslint-0.15.0-released.md
@@ -27,7 +27,7 @@ All of these options are off by default, and you can enable them in your configu
 
 ### New Rule: space-before-function-parentheses
 
-We had a significant gap in spacing after function names and before anonymous function parentheses. In order to cover this case, we removed `checkFunctionKeyword` option from `space-after-keywords` and deprecated `space-after-function-name` (it will be removed in 1.0.0). You should switch your code to use the new `[space-before-function-parentheses](http://eslint.org/docs/rules/space-before-function-parentheses.html)` as soon as possible.
+We had a significant gap in spacing after function names and before anonymous function parentheses. In order to cover this case, we removed `checkFunctionKeyword` option from `space-after-keywords` and deprecated `space-after-function-name` (it will be removed in 1.0.0). You should switch your code to use the new [`space-before-function-parentheses`](http://eslint.org/docs/rules/space-before-function-parentheses.html) as soon as possible.
 
 ### 1.0.0 Update
 


### PR DESCRIPTION
This was showing the markdown for creating the link instead of creating the link.