### PR TITLE
SEO fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,10 @@
-name: "ESLint"
-description: "A tool for identifying and reporting on patterns in JavaScript."
+name: "ESLint - Pluggable JavaScript linter"
+description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
 url: http://eslint.org
 markdown: redcarpet
 redcarpet:
     extensions: [with_toc_data]
 permalink: /blog/:year/:month/:title
 paginate: 25
+gems:
+    - jekyll-sitemap

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,11 +2,16 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="keywords" content="JavaScript, Linter, Linting, Pluggable, Configurable, Code Quality">
   <meta name="description" content="{{ site.description }}">
 {% if page.title != site.name %}
-  <title>{{ page.title }} - {{ site.name }}</title>
+    {% if page.title != "ESLint" %}
+        <title>{{ page.title }} - {{ site.name }}</title>
+    {% else %}
+        <title>{{ site.name }}</title>
+    {% endif %}
 {% else %}
   <title>{{ site.name }}</title>
 {% endif %}
@@ -37,32 +42,32 @@
             <span class="icon-bar"></span>
           </button>
           <a href="/" class="navbar-brand">
-            <img alt="" src="/img/logo.svg">
-            <span>ES</span>Lint</a>
+            <img alt="ESLint" src="/img/logo.svg">
+            ESLint</a>
         </div>
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/docs/user-guide/configuring.html">Configuring ESLint</a></li>
-                <li><a href="/docs/user-guide/command-line-interface.html">Command Line Interface</a></li>
+                <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
+                <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
                 <li><a href="/docs/rules/">Rules</a></li>
                 <li class="divider"></li>
-                <li><a href="/docs/user-guide/integrations.html">Integrations</a></li>
+                <li><a href="/docs/user-guide/integrations">Integrations</a></li>
               </ul>
             </li>
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Developer guide<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
-                <li><a href="/docs/developer-guide/contributing.html">Contributing</a></li>
-                <li><a href="/docs/developer-guide/source-code.html">Get the Source Code</a></li>
-                <li><a href="/docs/developer-guide/development-environment.html">Setup a Development Environment</a></li>
-                <li><a href="/docs/developer-guide/unit-tests.html">Run the Unit Tests</a></li>
-                <li><a href="/docs/developer-guide/working-with-rules.html">Working with Rules</a></li>
-                <li><a href="/docs/developer-guide/working-with-plugins.html">Working with Plugins</a></li>
-                <li><a href="/docs/developer-guide/nodejs-api.html">Node.js API</a></li>
-                <li><a href="/docs/developer-guide/governance.html">Governance Model</a></li>
+                <li><a href="/docs/developer-guide/contributing">Contributing</a></li>
+                <li><a href="/docs/developer-guide/source-code">Get the Source Code</a></li>
+                <li><a href="/docs/developer-guide/development-environment">Setup a Development Environment</a></li>
+                <li><a href="/docs/developer-guide/unit-tests">Run the Unit Tests</a></li>
+                <li><a href="/docs/developer-guide/working-with-rules">Working with Rules</a></li>
+                <li><a href="/docs/developer-guide/working-with-plugins">Working with Plugins</a></li>
+                <li><a href="/docs/developer-guide/nodejs-api">Node.js API</a></li>
+                <li><a href="/docs/developer-guide/governance">Governance Model</a></li>
               </ul>
             </li>
             <li><a href="/blog">Blog</a></li>

--- a/_layouts/demo.html
+++ b/_layouts/demo.html
@@ -1,5 +1,5 @@
 {% include header.html %}
-<link rel="stylesheet" type="text/css" href="http://eclipse.org/orion/editor/releases/current/built-editor.css" />
+<link rel="stylesheet" property="stylesheet" type="text/css" href="http://eclipse.org/orion/editor/releases/current/built-editor.css" />
 <div class="container">
     {{ content }}
 </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -2,7 +2,7 @@
 title: ESLint Demo
 layout: demo
 ---
-<link rel="stylesheet" href="../styles/demo.css"/>
+<link rel="stylesheet" property="stylesheet" href="../styles/demo.css"/>
 
 <div class="container editorRow">
     <div class="row">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-title: ESLint
+title: ESLint - Pluggable JavaScript linter
 layout: default
 ---
 <div class="container">
@@ -59,7 +59,7 @@ layout: default
             <div class="col-sm-6 col-md-6">
               <h2>Command Line Interface</h2>
               <p>ESLint is written to be used primarily on the command line. Learn about its usage here. </p>
-              <p><a class="btn btn-default" href="/docs/user-guide/command-line-interface.html" role="button">CLI Details »</a></p>
+              <p><a class="btn btn-default" href="/docs/user-guide/command-line-interface" role="button">CLI Details »</a></p>
             </div>
             <div class="col-sm-6 col-md-6">
               <h2>Developer Guide</h2>


### PR DESCRIPTION
fixes #31
Change site name to "ESLint - Pluggable JavaScript linter"
Fixed all W3C validator errors
Changed links to not include ".html" (Couldn't not verify this locally. Local jekyll doesn't work that way)
Added meta keywords
Added auto-generated sitemap