### PR TITLE
Temporary fix for broken links

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -386,5 +386,5 @@ The thing that makes ESLint different from other linters is the ability to defin
 Runtime rules are written in the same format as all other rules. Create your rule as you would any other and then follow these steps:
 
 1. Place all of your runtime rules in the same directory (i.e., `eslint_rules`).
-2. Create a [configuration file](../configuring) and specify your rule ID error level under the `rules` key. Your rule will not run unless it has a value of `1` or `2` in the configuration file.
-3. Run the [command line interface](../command-line-interface) using the `--rulesdir` option to specify the location of your runtime rules.
+2. Create a [configuration file](../user-guide/configuring) and specify your rule ID error level under the `rules` key. Your rule will not run unless it has a value of `1` or `2` in the configuration file.
+3. Run the [command line interface](../user-guide/command-line-interface) using the `--rulesdir` option to specify the location of your runtime rules.

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -50,7 +50,7 @@ Options:
 
 ### `-c`, `--config`
 
-This option allows you to specify an alternate configuration file for ESLint (see [Configuring ESLint](../configuring) for more). By default, ESLint uses its own configuration file located at `conf/eslint.json`.
+This option allows you to specify an alternate configuration file for ESLint (see [Configuring ESLint](configuring) for more). By default, ESLint uses its own configuration file located at `conf/eslint.json`.
 
 Example:
 
@@ -60,7 +60,7 @@ This example uses the configuration file at `~/my-eslint.json` instead of the de
 
 ### `--env`
 
-This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the flag multiple times.
+This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the flag multiple times.
 
 Examples:
 

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -9,7 +9,7 @@ layout: doc
 ESLint is designed to be completely configurable, meaning you can turn off every rule and run only with basic syntax validation, or mix and match the bundled rules and your custom rules to make ESLint perfect for your project. There are two primary ways to configure ESLint:
 
 1. **Configuration Comments** - use JavaScript comments to embed configuration information directly into a file.
-1. **Configuration Files** - use a JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an `.eslintrc` file or an `eslintConfig` field in a `package.json` file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](../command-line-interface).
+1. **Configuration Files** - use a JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an `.eslintrc` file or an `eslintConfig` field in a `package.json` file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](command-line-interface).
 
 There are several pieces of information that can be configured:
 
@@ -111,7 +111,7 @@ An environment defines both global variables that are predefined as well as whic
 
 These environments are not mutually exclusive, so you can define more than one at a time.
 
-Environments can be specified inside of a file, in configuration files or using the `--env` [command line](../command-line-interface) flag.
+Environments can be specified inside of a file, in configuration files or using the `--env` [command line](command-line-interface) flag.
 
 To specify environments using a comment inside of your JavaScript file, use the following format:
 
@@ -234,13 +234,13 @@ To configure rules inside of a file using configuration comments, use a comment 
 /*eslint eqeqeq:0, curly: 2*/
 ```
 
-In this example, [`eqeqeq`](../rules/eqeqeq.md) is turned off and [`curly`](../rules/curly.md) is turned on as an error. If a rule has additional options, you can specify them using array literal syntax, such as:
+In this example, [`eqeqeq`](rules/eqeqeq) is turned off and [`curly`](rules/curly) is turned on as an error. If a rule has additional options, you can specify them using array literal syntax, such as:
 
 ```js
 /*eslint quotes: [2, "double"], curly: 2*/
 ```
 
-This comment specifies the "double" option for the [`quotes`](../rules/quotes.md) rule.
+This comment specifies the "double" option for the [`quotes`](rules/quotes) rule.
 
 To configure rules inside of a configuration file, use the `rules` key along with an error level and any options you want to use. For example:
 


### PR DESCRIPTION
This is a temporary fix for broken links until next release of ESLint. I completely forgot to update links inside dynamic documentation files and they are currently broken on the site. I will make sure to create a mirror pull request in the main ESLint repository. Sorry about that, completely slipped my mind. (I also couldn't verify that the links work locally... Local Jekyll doesn't support extension-less urls).