### PR TITLE
Adding GitHub Link to header

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -39,6 +39,7 @@
                 <li><a href="/blog/">Blog</a></li>
                 <li><a href="/demo/">Demo</a></li>
                 <li><a href="/docs/about/">About</a></li>
+                <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
             </ul>
         </div>
     </div><!-- /.container -->


### PR DESCRIPTION
Not sure if it's just me but I always go looking for the link to the GitHub project in the header, then remember to scroll down to the footer to find it.

The GitHub project itself is particularly valuable when I'm trying to work out whether a certain rule is behaving as expected, is on the roadmap, etc. Would be nice to give it some more visibility.