### PR TITLE
Removed duplicate container

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@ title: ESLint - Pluggable JavaScript linter
 layout: default
 redirect_from: "/docs/"
 ---
-<div class="container">
 <div class="col-sm-7 col-md-12">
 
           <div class="row">
@@ -58,4 +57,3 @@ redirect_from: "/docs/"
               </div>
           </div>
     </div> <!-- /.col-md-12 -->
-</div>


### PR DESCRIPTION
_layouts/default.html already defined a container class. Each container class add 15px of padding making the website looks odd.