### PR TITLE
Adding Orion errors to the demo (fixes #21)

### DIFF
--- a/js/app/demo.js
+++ b/js/app/demo.js
@@ -83,6 +83,15 @@ require([
                 resultsNode.appendChild(resultNode);
             });
         }
+        editor.showProblems(results.map(function(error) {
+        	return {
+        		line: error.line,
+        		start: error.column + 1,
+        		end: error.column + 2,
+        		description: error.message + ' (' + error.ruleId + ')',
+        		severity: error.severity === 2 ? 'error' : 'warning'
+        	};
+        }));
     }
 
     function populateConfiguration(rules, environments) {


### PR DESCRIPTION
fixes #21 
This should add icons with errors/warning to the editor. It's too bad ESLint is only reporting starting position of error. Would be much nicer if it would report both start and end.