### PR TITLE
make urls links

### DIFF
--- a/docs/developer-guide/source-code.md
+++ b/docs/developer-guide/source-code.md
@@ -5,13 +5,13 @@ layout: doc
 
 # Source Code
 
-ESLint is hosted at [GitHub](http://www.github.com) and uses [Git](http://git-scm.com/) for source control. In order to obtain the source code, you must first install Git on your system. Instructions for installing and setting up Git can be found at http://help.github.com/set-up-git-redirect.
+ESLint is hosted at [GitHub](http://www.github.com) and uses [Git](http://git-scm.com/) for source control. In order to obtain the source code, you must first install Git on your system. Instructions for installing and setting up Git can be found at [http://help.github.com/set-up-git-redirect](http://help.github.com/set-up-git-redirect).
 
 If you simply want to create a local copy of the source to play with, you can clone the main repository using this command:
 
     git clone git://github.com/eslint/eslint.git
 
-If you're planning on contributing to ESLint, then it's a good idea to fork the repository. You can find instructions for forking a repository at http://help.github.com/fork-a-repo/. After forking the ESLint repository, you'll want to create a local copy of your fork.
+If you're planning on contributing to ESLint, then it's a good idea to fork the repository. You can find instructions for forking a repository at [http://help.github.com/fork-a-repo/](http://help.github.com/fork-a-repo/). After forking the ESLint repository, you'll want to create a local copy of your fork.
 
 ## Start Developing
 


### PR DESCRIPTION
The URLs at the top of http://eslint.org/docs/developer-guide/source-code aren't being turned into links.