### PR TITLE
Add link to overcommit Git hook manager

### DIFF
--- a/docs/user-guide/integrations.md
+++ b/docs/user-guide/integrations.md
@@ -39,6 +39,7 @@ redirect_from: "/docs/integrations/"
 ## Source Control
 
 * [Git Precommit Hook](https://coderwall.com/p/zq8jlq)
+* [overcommit Git hook manager](https://github.com/brigade/overcommit)
 
 ## Testing
 


### PR DESCRIPTION
overcommit is a fully configurable and extendable Git hook manager that
includes out-of-the-box support for running ESLint.