### PR TITLE
Fix: remove "s" from "arrays-" in array-bracket-spacing configuration example

### DIFF
--- a/docs/0.24.1/rules/array-bracket-spacing.md
+++ b/docs/0.24.1/rules/array-bracket-spacing.md
@@ -33,7 +33,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"arrays-bracket-spacing": [2, "always"]
+"array-bracket-spacing": [2, "always"]
 ```
 
 #### never

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -33,7 +33,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"arrays-bracket-spacing": [2, "always"]
+"array-bracket-spacing": [2, "always"]
 ```
 
 #### never


### PR DESCRIPTION
Fixes [eslint #3089](https://github.com/eslint/eslint/issues/3089).