### PR TITLE
Fix: Demo fail on undefined property check

### DIFF
--- a/js/app/demo.js
+++ b/js/app/demo.js
@@ -186,6 +186,9 @@ require([
     }
 
     var OPTIONS = JSON.parse(config);
+    if (!OPTIONS.env) {
+        OPTIONS.env = {};
+    }
     if (localStorage.rules) {
         OPTIONS.rules = JSON.parse(localStorage.rules);
     }


### PR DESCRIPTION
This solves the error we are seeing right now:

```sh
Uncaught TypeError: Cannot read property 'es6' of undefined
```