### PR TITLE
Fix: Scroll long code instead of wrapping (fixes #126)

### DIFF
--- a/styles/overrides.css
+++ b/styles/overrides.css
@@ -1,3 +1,13 @@
 .btn-getting-started {
   margin-top: 30px;
 }
+
+/* Prevent long code from wrapping, scroll instead */
+code[data-lang] {
+  white-space: pre;
+}
+
+main.doc .highlight pre {
+  overflow-x: auto;
+  word-wrap: normal;
+}


### PR DESCRIPTION
This unfortunately can't go into bootstrap.less, because it is overridden in `main.936b04d2.css`.  The other option is to edit that file (main), which is possible, but ugly.