### PR TITLE
Add Algolia search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 _site/
+_algolia_api_key

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+cache: bundler
+branches:
+  only:
+    - master
+script: 
+  - bundle exec jekyll algolia push
+rvm:
+ - 2.2

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,8 @@
 name: "ESLint - Pluggable JavaScript linter"
+exclude: [
+  'node_modules',
+  'vendor'
+]
 description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
 url: http://eslint.org
 markdown: redcarpet
@@ -7,3 +11,29 @@ paginate: 25
 gems:
     - jekyll-sitemap
     - jekyll-redirect-from
+    - algoliasearch-jekyll
+algolia:
+  application_id: 'XWXG7MEBSB'
+  index_name:     'eslint'
+  record_css_selector: p,li,tr,h1,h2,h3,h4,h5,h6
+  settings:
+    advancedSyntax: true
+    highlightPostTag: </mark>
+    highlightPreTag: <mark>
+    minWordSizefor1Typo: 3
+    minWordSizefor2Typos: 7
+    attributesToIndex:
+      - title
+      - text
+      - category,subcategory,display_title # Needed for the highlight
+    attributesToHighlight:
+      - category
+      - subcategory
+      - display_title
+      - text
+    customRanking:
+      - desc(weight.type)
+      - desc(weight.tag_name)
+      - asc(weight.position)
+    attributesToSnippet:
+      - text:20

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,9 +13,26 @@
       </footer>
     </div><!-- /.container -->
 
+
+  <script id="suggestion-item-template" type="text/template">
+  {%raw %}
+  {{#isCategoryHeader}}<div class="suggestion-category">{{{category}}}</div>{{/isCategoryHeader}}
+  <div class="suggestion {{#isCategoryHeader}}suggestion-is-category-header{{/isCategoryHeader}}">
+    <div class="suggestion-subcategory-main">{{#isSubcategoryHeader}}{{{subcategory}}}{{/isSubcategoryHeader}}</div>
+    <div class="suggestion-content">
+      <div class="suggestion-subcategory-secondary">{{{subcategory}}}</div>
+      <div class="suggestion-title">{{{title}}}</div>
+      <div class="suggestion-text">{{{text}}}</div>
+    </div>
+  </div>
+  {% endraw %}
+  </script>
+
   <script src="/js/vendor/jquery-1.10.2.min.js"></script>
   <script src="/js/vendor/bootstrap.min.js"></script>
   <script src="/js/vendor/anchor.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/g/lodash@3.10.1,hogan.js@3.0.2,algoliasearch@3.8.1,autocomplete.js@0.12.0(autocomplete.min.js)"></script>
+  <script src="/js/app/search.js"></script>
   <script>
     $(document).ready(function() {
       anchors.add('.doc h2, .doc h3, .doc h4, .blog h2, .blog h3, .blog h4');

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -19,6 +19,7 @@
   <link href="{{ site.url }}{{ page.url }}" rel="canonical" />
   <link rel="stylesheet" href="/styles/main.936b04d2.css"/>
   <link rel="stylesheet" href="/styles/ads.css"/>
+  <link rel="stylesheet" href="/styles/search.css"/>
   <link rel="stylesheet" href="/styles/overrides.css"/>
   <link rel="icon" href="/img/favicon.512x512.png">
   <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,54 +1,80 @@
-<header class="navbar navbar-default navbar-demo" role="navigation">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-            <a href="/" class="navbar-brand">
-                <img alt="ESLint" src="/img/logo.svg" itemprop="image">
-                ESLint</a>
+<input type="checkbox" id="eslint-toggle-search" class="eslint-toggle-search-checkbox" />
+<header class="navbar navbar-default navbar-demo navbar-fixed-top eslint-nav" id="top" role="banner">
+  <div class="container">
+
+    <a href="/" class="navbar-brand"><img alt="ESLint" src="/img/logo.svg" itemprop="image">ESLint</a>
+
+    <div class="eslint-navbar-toggles">
+      <button class="navbar-toggle collapsed" type="button" data-toggle="collapse" data-target="#eslint-navbar" aria-controls="eslint-navbar" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+
+      <label for="eslint-toggle-search" class="navbar-toggle eslint-toggle-search-open">
+        <span class="sr-only">Open search</span>
+        <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+      </label>
+    </div>
+
+    <nav id="eslint-navbar" class="collapse navbar-collapse eslint-navbar">
+      <ul class="nav navbar-nav navbar-right">
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
+            <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
+            <li><a href="/docs/rules/">Rules</a></li>
+            <li class="divider"></li>
+            <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
+            <li><a href="/docs/user-guide/integrations">Integrations</a></li>
+          </ul>
+        </li>
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Developer guide<span class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="/docs/developer-guide/architecture">Architecture</a></li>
+            <li><a href="/docs/developer-guide/contributing">Contributing</a></li>
+            <li><a href="/docs/developer-guide/source-code">Get the Source Code</a></li>
+            <li><a href="/docs/developer-guide/development-environment">Setup a Development Environment</a></li>
+            <li><a href="/docs/developer-guide/unit-tests">Run the Unit Tests</a></li>
+            <li><a href="/docs/developer-guide/working-with-rules">Working with Rules</a></li>
+            <li><a href="/docs/developer-guide/working-with-plugins">Working with Plugins</a></li>
+            <li><a href="/docs/developer-guide/shareable-configs">Shareable Configs</a></li>
+            <li><a href="/docs/developer-guide/nodejs-api">Node.js API</a></li>
+            <li><a href="/docs/developer-guide/governance">Governance Model</a></li>
+          </ul>
+        </li>
+        <li><a href="/blog/">Blog</a></li>
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Demo<span class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="/demo/">ESLint Demo</a></li>
+            <li><a href="/parser/">Espree Demo</a></li>
+          </ul>
+        </li>
+        <li><a href="/docs/about/">About</a></li>
+      </ul>
+
+      <label for="eslint-toggle-search" class="navbar-toggle eslint-toggle-search-open">
+        <span class="sr-only">Open search</span>
+        <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+      </label>
+
+      <div class="navbar-form navbar-right eslint-search" role="search">
+        <div class="input-group">
+          <label class="sr-only" aria-label="Search" for="eslint-search-input">Search</label>
+          <div class="eslint-search-input-wrapper">
+            <input type="text" class="form-control" id="eslint-search-input" accesskey="s" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the docs...">
+            <label for="eslint-toggle-search" class="eslint-toggle-search-close">
+              <span class="sr-only">Close search</span>
+              <span class="glyphicon glyphicon-remove-circle" aria-hidden="true"></span>
+            </label>
+          </div>
         </div>
-        <nav class="collapse navbar-collapse">
-            <ul class="nav navbar-nav navbar-right">
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
-                    <ul class="dropdown-menu" role="menu">
-                        <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
-                        <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
-                        <li><a href="/docs/rules/">Rules</a></li>
-                        <li class="divider"></li>
-                        <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
-                        <li><a href="/docs/user-guide/integrations">Integrations</a></li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Developer guide<span class="caret"></span></a>
-                    <ul class="dropdown-menu" role="menu">
-                        <li><a href="/docs/developer-guide/architecture">Architecture</a></li>
-                        <li><a href="/docs/developer-guide/contributing">Contributing</a></li>
-                        <li><a href="/docs/developer-guide/source-code">Get the Source Code</a></li>
-                        <li><a href="/docs/developer-guide/development-environment">Setup a Development Environment</a></li>
-                        <li><a href="/docs/developer-guide/unit-tests">Run the Unit Tests</a></li>
-                        <li><a href="/docs/developer-guide/working-with-rules">Working with Rules</a></li>
-                        <li><a href="/docs/developer-guide/working-with-plugins">Working with Plugins</a></li>
-                        <li><a href="/docs/developer-guide/shareable-configs">Shareable Configs</a></li>
-                        <li><a href="/docs/developer-guide/nodejs-api">Node.js API</a></li>
-                        <li><a href="/docs/developer-guide/governance">Governance Model</a></li>
-                    </ul>
-                </li>
-                <li><a href="/blog/">Blog</a></li>
-                <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Demo<span class="caret"></span></a>
-                    <ul class="dropdown-menu" role="menu">
-                        <li><a href="/demo/">ESLint Demo</a></li>
-                        <li><a href="/parser/">Espree Demo</a></li>
-                    </ul>
-                </li>
-                <li><a href="/docs/about/">About</a></li>
-            </ul>
-        </nav>
-    </div><!-- /.container -->
+      </div>
+    </nav>
+
+  </div><!-- /.container -->
 </header><!-- /.navbar -->

--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -1,0 +1,150 @@
+class AlgoliaSearchRecordExtractor
+  def custom_hook_each(item, node)
+    EslintCustomSearchHelper.hook_each(item, node)
+  end
+end
+
+class EslintCustomSearchHelper
+  def self.hook_each(item, node)
+    return nil if excluded_page(item)
+
+    record = {
+      weight: item[:weight],
+      tag_name: item[:tag_name]
+    }
+
+    # Grabbing information on the position of the record in the page hierarchy
+    hierarchy_info = hierarchy_info(item)
+    return nil if excluded_item(item, hierarchy_info)
+    record = record.merge(hierarchy_info)
+
+    # We store the content in `title` for the headings and in `text` for the
+    # other nodes
+    if heading?(item[:tag_name])
+      record[:title] = item[:text].gsub('"', '')
+      record[:text] = nil
+    else
+      record[:title] = nil
+      record[:text] = item[:text]
+    end
+
+    # We find the url to get to this content
+    record[:url] = url(item, record)
+
+    record
+  end
+
+  # Items from pages we do not want to index
+  def self.excluded_page(item)
+    # Blog posts are mostly changelogs
+    return true if blog?(item)
+    # This pages should not be indexed, they do not contain any interesting data
+    return true if item[:url] == '/blog/index.html'
+    return true if item[:url] == '/cla/index.html'
+    return true if item[:url] == '/demo/index.html'
+    return true if item[:url] == '/docs/rules/index.html'
+    return true if item[:url] == '/docs/user-guide/integrations/index.html'
+    return true if item[:url] == '/index.html'
+    return true if item[:url] == '/parser/index.html'
+    # Old docs
+    return true if item[:url] =~ %r{^/docs/0.24.1/}
+    return true if item[:url] =~ %r{^/docs/1.0.0/}
+    # Redirect pages
+    return true if item[:type] == 'redirectpage'
+    false
+  end
+
+  # Items that we do not want to index
+  def self.excluded_item(item, hierarchy_data)
+    # Exclude all redirection
+    return true unless item[:redirect_to].nil?
+    # Exclude some parts of the page
+    closest_heading = hierarchy_data[:hierarchy][-1]
+    return true if closest_heading == 'Further Reading'
+    return true if closest_heading == 'Version'
+    return true if closest_heading == 'Related Rules'
+    return true if closest_heading == 'Resources'
+    return true if closest_heading == 'The following patterns are considered problems:'
+    return true if closest_heading == 'The following patterns are not considered problems:'
+    false
+  end
+ 
+  def self.blog?(item)
+    item[:url] =~ %r{^/blog/}
+  end
+
+  def self.rule?(item)
+    item[:url] =~ %r{^/docs/rules/}
+  end
+
+  def self.heading?(tag_name)
+    %w(h1 h2 h3 h4 h5 h6).include?(tag_name)
+  end
+
+  # Returns information about the item place in the page hierarchy
+  # - main category (eg. Rule, Blog, etc)
+  # - subcategory (eg. accessor-pairs, ESLint v1.7.0 released)
+  # - display title (eg. Rule details, Rule details > getWithoutSet)
+  # - hierarchy, array of all parent heading in order
+  # - parent_heading_type, which heading is the closest
+  def self.hierarchy_info(item)
+    hierarchy = []
+
+    %w(h1 h2 h3 h4 h5 h6).each do |h|
+      hierarchy << item[h.to_sym] if item[h.to_sym]
+    end
+
+    if rule?(item)
+      # Split the main name in rule name and description
+      split = hierarchy.shift.match(/(.*) \((.*)\)$/).captures
+      rule_name = split[1]
+      rule_description = split[0]
+      hierarchy = ['Rules', rule_name, rule_description] + hierarchy
+    end
+
+    # Find the first three levels of display
+    category = hierarchy[0]
+    subcategory = hierarchy[1]
+    display_title = [hierarchy[2], hierarchy[-1]].uniq.compact.join(' › ')
+
+    # Find the closest parent heading type (including self)
+    parent_heading_type = nil
+    %w(h1 h2 h3 h4 h5 h6).each do |heading_type|
+      break if item[heading_type.to_sym].nil?
+      parent_heading_type = heading_type
+    end
+
+    {
+      hierarchy: hierarchy,
+      category: category,
+      subcategory: subcategory,
+      display_title: display_title,
+      parent_heading_type: parent_heading_type
+    }
+  end
+
+  # Anchors are added through the front-end so we'll have to generate them
+  # before indexing the records
+  def self.url(initial_item, parsed_item)
+    closest_heading_type = parsed_item[:parent_heading_type]
+
+    # Url is correct for top level element (under h1)
+    return initial_item[:url] if closest_heading_type == 'h1'
+    # Otherwise we guess it from the closest heading
+    closest_heading_value = initial_item[closest_heading_type.to_sym]
+    anchor = anchor(closest_heading_value)
+    "#{initial_item[:url]}##{anchor}"
+  end
+
+  # Convert text to usable id
+  def self.anchor(rough_text)
+    # Ruby transcription of:
+    # https://github.com/bryanbraun/anchorjs/blob/master/anchor.js
+    tidy_text = rough_text.gsub(/[^\w\s-]/, '')
+    tidy_text = tidy_text.gsub(/\s+/, '-')
+    tidy_text = tidy_text.gsub(/-{2,}/, '-')
+    tidy_text = tidy_text[0, 64]
+    tidy_text = tidy_text.gsub(/^-+|-+$/, '')
+    tidy_text.downcase
+  end
+end

--- a/js/app/search.js
+++ b/js/app/search.js
@@ -1,0 +1,96 @@
+/* global jQuery, autocomplete */
+
+(function ($) {
+  'use strict';
+  var client = algoliasearch('XWXG7MEBSB', '653e00f423bee91f9863571eed16f2f5');
+  var suggestionTemplate = window.Hogan.compile($('#suggestion-item-template').text());
+  var searchInputSelector = '#eslint-search-input';
+  var $searchInput = $(searchInputSelector);
+
+  // Calls the Algolia API to get results matching the query
+  function autocompleteSource(query, callback) {
+    client.search([{
+      indexName: 'eslint',
+      query: query,
+      params: {
+        hitsPerPage: 5
+      }
+    }], function (err, data) {
+      callback(formatHits(data.results[0].hits));
+    });
+  }
+
+  // Reorder hits to group them by section
+  function formatHits(hits) {
+    // Flatten all values into one array, marking the first element with
+    // `flagName`
+    function flattenObject(o, flagName) {
+      var values = _.map(_.values(o), function(value) {
+        value[0][flagName] = true;
+        return value;
+      });
+      return _.flatten(values);
+    }
+
+    // Group hits by category / subcategory
+    var groupedHits = _.groupBy(hits, 'category');
+    _.each(groupedHits, function(list, category) {
+      var groupedHitsBySubCategory = _.groupBy(list, 'subcategory');
+      var flattenedHits = flattenObject(groupedHitsBySubCategory, 'isSubcategoryHeader');
+      groupedHits[category] = flattenedHits;
+    });
+    groupedHits = flattenObject(groupedHits, 'isCategoryHeader');
+
+    // Translate hits into smaller objects to be send to the template
+    return _.map(groupedHits, function(hit) {
+      return {
+        isCategoryHeader: hit.isCategoryHeader,
+        isSubcategoryHeader: hit.isSubcategoryHeader,
+        category: hit._highlightResult.category ? hit._highlightResult.category.value : hit.category,
+        subcategory: hit._highlightResult.subcategory ? hit._highlightResult.subcategory.value : hit.category,
+        title: hit._highlightResult.display_title ? hit._highlightResult.display_title.value : hit.display_title,
+        text: hit._snippetResult ? hit._snippetResult.text.value : hit.text,
+        url: hit.url
+      };
+    });
+  }
+
+  var search = autocomplete(searchInputSelector, {
+    hint: false
+  }, [
+    {
+      source: autocompleteSource,
+      displayKey: function () {
+        return $searchInput.val();
+      },
+      templates: {
+        suggestion: function(suggestion) {
+          return suggestionTemplate.render(suggestion);
+        }
+      }
+    }
+  ]).on('autocomplete:selected', function(event, suggestion) {
+    search.autocomplete.setVal('');
+    window.location.href = suggestion.url;
+  });
+
+  // Init autocomplete
+  $(function () {
+    $('html').removeClass('no-js').addClass('js');
+
+    // Toggle and focus the search bar when clicking on the magnifying glass on
+    // small devices. This is achieved through a label and corresponding
+    // checkbox.
+    // This could have been done in complete HTML except that it does not work
+    // on iOS (focus can only be triggered from user interaction), so we need to
+    // replicate the behavior using JavaScript.
+    var $toggleCheckbox = $('#eslint-toggle-search');
+    var $toggleLabels = $('.eslint-toggle-search-open');
+    $toggleLabels.on('click', function (e) {
+      $toggleCheckbox.click();
+      $searchInput.focus();
+      e.preventDefault();
+    });
+  });
+})(jQuery);
+

--- a/styles/overrides.css
+++ b/styles/overrides.css
@@ -11,3 +11,21 @@ main.doc .highlight pre {
   overflow-x: auto;
   word-wrap: normal;
 }
+
+/* We need to push the content because of the fixed header */
+body {
+  padding-top: 80px;
+}
+/* Allow anchors to not be hidden by the fixed header */
+h1:target:before,
+h2:target:before,
+h3:target:before,
+h4:target:before,
+h5:target:before,
+h6:target:before {
+  content: "";
+  display: block;
+  margin-top: -80px;
+  height: 80px;
+  width: 1px;
+}

--- a/styles/search.css
+++ b/styles/search.css
@@ -1,0 +1,281 @@
+
+/* Hide every mention of search if JavaScript is disabled */
+.no-js .eslint-nav .eslint-navbar .eslint-toggle-search-open,
+.no-js .eslint-nav .eslint-navbar-toggles .eslint-toggle-search-open,
+.no-js .eslint-navbar .eslint-search {
+  display: none;
+}
+
+/* We revert the right/left padding because we changed the underlying markup */
+.eslint-nav .navbar-brand {
+  margin-left: -15px;
+}
+
+.eslint-nav .eslint-navbar-toggles {
+  margin-right: -15px;
+}
+
+/* On small screens, the display of the search bar on top of the menu is toggled */
+/* through a checkbox, when clicking on the matching label. The checkbox is */
+/* hidden, and we have two labels (pointing to the same checkbox), for two */
+/* different RWD breakpoints. */
+.eslint-toggle-search-checkbox {
+  display: none;
+}
+
+ /* Magnifying glass label */
+.eslint-toggle-search-open {
+  color: #463fd4;
+  cursor: pointer;
+  margin: 21px 15px 21px 0;
+  padding: 6px 10px 2px 10px;
+}
+ /* Hiding the second magnifying glass that will only be used on bigger screen */
+.eslint-navbar .eslint-toggle-search-open {
+  display: none;
+}
+
+
+ /* When the checkbox is checked, we hide everything in the .eslint-nav, except */
+ /* the form input */
+ /* Hide all */
+.eslint-toggle-search-checkbox:checked + .eslint-nav .navbar-brand,
+.eslint-toggle-search-checkbox:checked + .eslint-nav .eslint-navbar-toggles,
+.eslint-toggle-search-checkbox:checked + .eslint-nav .navbar-nav {
+  display: none;
+}
+ /* Display search */
+.eslint-toggle-search-checkbox:checked + .eslint-nav .eslint-navbar {
+  border-top: 0;
+  display: block;
+  visibility: visible;
+}
+.eslint-toggle-search-checkbox:checked + .eslint-nav .eslint-navbar .eslint-search {
+  display: block;
+}
+
+ /* Search input for small screen */
+.eslint-navbar .eslint-search {
+  border-color: transparent;
+  display: none;
+  margin: 0 -15px;
+  padding: 20px 15px 15px 15px;
+}
+ /* We need to play with display table to align the form element in the header */
+.eslint-search .eslint-search-input-wrapper {
+  display: table;
+  width: 100%;
+  border-bottom: 2px solid #463fd4;
+}
+.eslint-search .eslint-search-input-wrapper:before {
+  content: "\e003";
+  display: table-cell;
+  color: #463fd4;
+  vertical-align: middle;
+  font-family: "Glyphicons Halflings";
+  text-align: center;
+  width: 30px;
+}
+
+.eslint-search .eslint-toggle-search-close {
+  cursor: pointer;
+  display: table-cell;
+  vertical-align: middle;
+  color: #463fd4;
+  width: 30px;
+}
+ /* We hide the submit button, so we need to round the corners of the input */
+.eslint-search .input-group-btn {
+  display: none;
+}
+
+.eslint-nav .eslint-search .form-control {
+  font-weight: normal;
+  box-shadow: none;
+  border-color: transparent;
+  background-color: transparent;
+}
+
+ /* Fix display of nav elements in dropdown hamburger list */
+.eslint-nav .eslint-navbar {
+  clear: both;
+}
+
+/* Enough room to display the links, but not the full search. We'll only add */
+/* a magnifying glass to toggle the search */
+@media (min-width: 768px) {
+  .eslint-nav .eslint-navbar {
+    clear: none;
+  }
+  /* Show magnifying glass */
+  .eslint-nav .eslint-navbar .eslint-toggle-search-open {
+    color: #666;
+    display: block;
+    border: none;
+  }
+  .eslint-nav .eslint-navbar .eslint-toggle-search-open:hover {
+    background: transparent;
+    color: #444;
+  }
+  /* Hide the magnifying glass */
+  .eslint-toggle-search-checkbox:checked + .eslint-nav .eslint-toggle-search-open {
+    display: none;
+  }
+  /* Force the search to take all available space */
+  .eslint-toggle-search-checkbox:checked + .eslint-nav .eslint-navbar .eslint-search {
+    width: 100%;
+    margin: 0;
+  }
+}
+
+/* Enough room to display the input directly in the header */
+@media (min-width: 996px) {
+   /* Hide magnifying glass and close button */
+  .eslint-nav .eslint-search .eslint-toggle-search-close,
+  .eslint-nav .eslint-navbar .eslint-toggle-search-open {
+    display: none;
+  }
+   /* Show search */
+  .eslint-nav .eslint-search {
+    display: block;
+    width: 325px;
+  }
+  /* Tone down the colors a bit */
+  .eslint-search .eslint-search-input-wrapper {
+    border-color: #666;
+  }
+  .eslint-search .eslint-search-input-wrapper:before {
+    color: #666;
+  }
+}
+
+
+/* Main autocomplete wrapper */
+.eslint-nav .algolia-autocomplete {
+  width: 100%;
+}
+.eslint-nav .aa-dropdown-menu {
+  background-color: #FFF;
+  border: 1px solid #333;
+  border-radius: 4px;
+  font-size: 16px;
+  margin: 6px 0 0;
+  padding: 4px;
+  text-align: left;
+  left: -20px !important;
+  right: -20px !important;
+}
+
+/* Category headers */
+.eslint-nav .suggestion-category {
+  background-color: #4B54DE;
+  color: white;
+  font-weight: 600;
+  padding: 5px 10px;
+  text-align: left;
+}
+.eslint-nav .suggestion-category mark {
+  background-color: #4D47D5;
+  color: white;
+  padding: 0;
+}
+
+/* Suggestion */
+.eslint-nav .suggestion {
+  color: #333;
+  cursor: pointer;
+  overflow: hidden;
+  border-bottom: 1px solid #3A33D1;
+}
+.eslint-nav .aa-suggestion:last-child .suggestion {
+  border-bottom-color: transparent;
+}
+.eslint-nav .suggestion mark {
+  padding: 0;
+  color: #3A33D1;
+  background: none;
+  font-weight: 600;
+}
+.eslint-nav .suggestion-subcategory-secondary {
+  display: inline-block;
+  font-weight: bold;
+}
+.eslint-nav .suggestion-subcategory-secondary:after {
+  content: " › ";
+}
+.eslint-nav .suggestion-title {
+  display: inline;
+}
+.eslint-nav .suggestion-content {
+  padding: 3px 5px;
+}
+/* Hidden elements for this viewport */
+.eslint-nav .suggestion-subcategory-main,
+.eslint-nav .suggestion-text {
+  display: none;
+}
+
+/* Selected suggestion */
+.eslint-nav .aa-cursor .suggestion-content,
+.eslint-nav .aa-cursor .suggestion-content code,
+.eslint-nav .aa-cursor .suggestion-content mark {
+  color: #272296;
+}
+.eslint-nav .aa-cursor .suggestion {
+  background: #EBEBFB;
+}
+
+/* Screen big enough to display the text snippets */
+@media (min-width: 568px) {
+  .eslint-nav .suggestion-text {
+    display: block;
+    font-size: .9em;
+  }
+}
+
+/* Screen big enough to display results in two columns */
+@media (min-width: 768px) {
+   /* Use table display for the two columns */
+  .eslint-nav .suggestion {
+    display: table;
+    width: 100%;
+    border-bottom: 1px solid #9D99E8;
+  }
+  .eslint-nav .suggestion-subcategory-main {
+    border-right: 1px solid #9D99E8;
+    background: #F2F2FF;
+    color: #4E4726;
+    display: table-cell;
+    max-width: 135px;
+    min-width: 135px;
+    overflow: hidden;
+    padding: 5px 7px 5px 5px;
+    text-align: right;
+    text-overflow: ellipsis;
+    vertical-align: top;
+    width: 135px;
+  }
+  .eslint-nav .suggestion-content {
+    display: table-cell;
+    padding: 5px 10px;
+  }
+  .eslint-nav .suggestion-subcategory-secondary {
+    display: none;
+  }
+  .eslint-nav .suggestion-title {
+    font-weight: 600;
+  }
+  .eslint-nav .suggestion-text {
+    display: block;
+    font-weight: normal;
+    padding: 2px;
+  }
+}
+
+/* Enough room to display the autocomplete in the header directly */
+@media (min-width: 996px) {
+  .eslint-nav .aa-dropdown-menu {
+    left: -30px !important;
+    right: -270px !important;
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/eslint/eslint.github.io/issues/69, here is my proposal for adding search to the eslint website using the Algolia API. You can test it live on http://eslint.algolia.com/.


![2015-11-06_17h33m35](https://cloud.githubusercontent.com/assets/283419/11002478/3e33af48-84ad-11e5-9b5f-8573023d1136.gif)


It was done using our [Jekyll plugin](https://github.com/algolia/algoliasearch-jekyll). It includes a few specific tweaks to better adapt to the eslint doc (does not search in the blog changelogs, nor in previous rule versions for example). I've added several RWD displays of the searchbar + results.

It is currently hosted on one of my demo accounts, but if you open an account on Algolia, I'll make it unlimited and move all the data to it.

I've also added the necessary travis config files so it should rebuild the search index on every new push on master. It only requires you to configure your Travis with the correct `ALGOLIA_API_KEY` environment variable ([more info here](https://github.com/algolia/algoliasearch-jekyll#3-configure-travis)). Otherwise, you just have to call `jekyll algolia push` to re-index manually.

Tell me what you think