### PR TITLE
Add styles for recommended / fixable badges.

### DIFF
--- a/styles/overrides.css
+++ b/styles/overrides.css
@@ -7,6 +7,21 @@ code[data-lang] {
   white-space: pre;
 }
 
+a[href="#recommended"], a[href="#fixable"] {
+  text-decoration: none;
+  pointer-events: none;
+}
+
+a[href="#recommended"] code {
+  background-color: #fff3c9;
+  color: #8a6500;
+}
+
+a[href="#fixable"] code {
+  background-color: #c8deb9;
+  color: #2f8000;
+}
+
 main.doc .highlight pre {
   overflow-x: auto;
   word-wrap: normal;


### PR DESCRIPTION
Makes the recommended and fixable rules more visible at first glance (and subsequent glances).

Example renderings:

![image](https://cloud.githubusercontent.com/assets/174864/11012198/f2794cd6-84be-11e5-83f6-a644619456a8.png)

![image](https://cloud.githubusercontent.com/assets/174864/11012201/feebda56-84be-11e5-9b5f-3564ed74da68.png)

![image](https://cloud.githubusercontent.com/assets/174864/11012208/0cdbfc90-84bf-11e5-8eeb-a3d40a0c15cf.png)
