### PR TITLE
Add Gemfile for Travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 2.5.3'
+
+group :jekyll_plugins do
+  gem 'algoliasearch-jekyll', '~> 0.5.1'
+  gem 'jekyll-sitemap', '~> 0.8.1'
+  gem 'jekyll-redirect-from', '~> 0.8.0'
+end


### PR DESCRIPTION
Fixes #159 

The `bundle install` command ran by Travis should correctly find the `Gemfile` and install the needed plugins before running `bundle exec jekyll algolia push`.

Let me know if this works (or not).