### PR TITLE
Fix whitespace issue

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -129,7 +129,7 @@ Environments can be specified inside of a file, in configuration files or using 
 To specify environments using a comment inside of your JavaScript file, use the following format:
 
 ```js
-/*eslint-env node, mocha */
+/* eslint-env node, mocha */
 ```
 
 This enables Node.js and Mocha environments.


### PR DESCRIPTION
Replace example comment:

 ```js
/*eslint-env node, mocha */
 ```

with:

 ```js
/*eslint-env node, mocha */
 ```

**Reason:**
The example caused a linting error. 

```bash
1:1   error  Expected space or tab after "/*" in comment  spaced-comment
```

