### PR TITLE
Stop indexing v2.0.0 in search

### DIFF
--- a/_plugins/search.rb
+++ b/_plugins/search.rb
@@ -49,6 +49,8 @@ class EslintCustomSearchHelper
     # Old docs
     return true if item[:url] =~ %r{^/docs/0.24.1/}
     return true if item[:url] =~ %r{^/docs/1.0.0/}
+    # Beta docs
+    return true if item[:url] =~ %r{^/docs/2.0.0/}
     # Redirect pages
     return true if item[:type] == 'redirectpage'
     false


### PR DESCRIPTION
I've excluded all urls matching `/docs/2.0.0/` from the indexing, so those docs should not be displayed in the searchbar.

### Before
![image](https://cloud.githubusercontent.com/assets/283419/12450663/4d92fd14-bf85-11e5-9c42-0a9c17f04853.png)


### After
![image](https://cloud.githubusercontent.com/assets/283419/12450657/47c519f8-bf85-11e5-89c2-217c8408d35c.png)

Should fix #177 
