### PR TITLE
Fixed typo, added rules mentioned in previous post

### DIFF
--- a/_posts/2016-01-29-eslint-v2.0.0-beta.3-released.md
+++ b/_posts/2016-01-29-eslint-v2.0.0-beta.3-released.md
@@ -95,12 +95,17 @@ There are several new rules for this release:
 
 * [`array-callback-return`](http://eslint.org/docs/2.0.0/rules/array-callback-return)
 * [`id-blacklist`](http://eslint.org/docs/2.0.0/rules/id-blacklist)
+* [`keyword-spacing`](http://eslint.org/docs/2.0.0/rules/keyword-spacing)
 * [`no-confusing-arrow`](http://eslint.org/docs/2.0.0/rules/no-confusing-arrow)
 * [`no-implicit-globals`](http://eslint.org/docs/2.0.0/rules/no-implicit-globals)
+* [`no-new-symbol`](http://eslint.org/docs/2.0.0/rules/no-new-symbol)
 * [`no-restricted-imports`](http://eslint.org/docs/2.0.0/rules/no-restricted-imports)
 * [`no-unmodified-loop-condition`](http://eslint.org/docs/2.0.0/rules/no-unmodified-loop-condition)
-* [`one-var-declaration-per-line](http://eslint.org/docs/2.0.0/rules/one-var-declaration-per-line)
+* [`no-useless-constructor`](http://eslint.org/docs/2.0.0/rules/no-useless-constructor)
+* [`no-whitespace-before-property`](http://eslint.org/docs/2.0.0/rules/no-whitespace-before-property)
+* [`one-var-declaration-per-line`](http://eslint.org/docs/2.0.0/rules/one-var-declaration-per-line)
 * [`prefer-rest-params`](http://eslint.org/docs/2.0.0/rules/prefer-rest-params)
+* [`sort-imports`](http://eslint.org/docs/2.0.0/rules/sort-imports)
 * [`yield-star-spacing`](http://eslint.org/docs/2.0.0/rules/yield-star-spacing)
 
 


### PR DESCRIPTION
There was a backtick missing on the one-var-declaration-per-line line.
The other missing rules were the same ones that had to be fixed in the previous post by #184