### PR TITLE
simplify bulleted lists under Build Systems and Testing

### DIFF
--- a/docs/user-guide/integrations.md
+++ b/docs/user-guide/integrations.md
@@ -21,22 +21,14 @@ redirect_from: "/docs/integrations/"
 
 ## Build Systems
 
-* **Grunt:**
-    * [grunt-eslint](https://npmjs.org/package/grunt-eslint)
-* **Gulp:**
-    * [gulp-eslint](https://npmjs.org/package/gulp-eslint)
-* **Mimosa:**
-    * [mimosa-eslint](https://npmjs.org/package/mimosa-eslint)
-* **Broccoli:**
-    * [broccoli-eslint](https://www.npmjs.org/package/broccoli-eslint)
-* **Browserify**
-    * [eslintify](https://www.npmjs.com/package/eslintify)
-* **Webpack:**
-    * [eslint-loader](https://www.npmjs.org/package/eslint-loader)
-* **Ember-cli**
-    * [ember-cli-eslint](https://www.npmjs.com/package/ember-cli-eslint)
-* **Sails.js**
-    * [sails-hook-eslint](https://www.npmjs.com/package/sails-hook-eslint)
+* Grunt: [grunt-eslint](https://npmjs.org/package/grunt-eslint)
+* Gulp: [gulp-eslint](https://npmjs.org/package/gulp-eslint)
+* Mimosa: [mimosa-eslint](https://npmjs.org/package/mimosa-eslint)
+* Broccoli: [broccoli-eslint](https://www.npmjs.org/package/broccoli-eslint)
+* Browserify: [eslintify](https://www.npmjs.com/package/eslintify)
+* Webpack: [eslint-loader](https://www.npmjs.org/package/eslint-loader)
+* Ember-cli: [ember-cli-eslint](https://www.npmjs.com/package/ember-cli-eslint)
+* Sails.js: [sails-hook-eslint](https://www.npmjs.com/package/sails-hook-eslint)
 
 ## Command Line Tools
 
@@ -51,8 +43,7 @@ redirect_from: "/docs/integrations/"
 
 ## Testing
 
- * **Mocha.js**
-    * [mocha-eslint](https://www.npmjs.com/package/mocha-eslint)
+ * Mocha.js: [mocha-eslint](https://www.npmjs.com/package/mocha-eslint)
 
 ## External ESLint rules
 


### PR DESCRIPTION
To reduce scrolling and visual complexity, make bulleted points (which have standard *-eslint packages) follow the pattern of Atom under Editors.

This is my warm-up exercise before the main work to improve information architecture.