### PR TITLE
Update parser demo for espree 3.0 (fixes #196)

### DIFF
--- a/js/app/parser/index.built.js
+++ b/js/app/parser/index.built.js
@@ -7,32 +7,67 @@ var lib = require('./lib');
 var editor = document.querySelector('#editor');
 var results = document.querySelector('#results');
 var controls = document.querySelector('#configuration');
-var optionsControl = document.querySelector('.options .list');
 
-function handleBodyClick(event) {
-	if (event.target.classList.contains('option-checkbox')) {
-		toggleControl(event.target.id);
+function handleSelectChange(property, el) {
+	var selected = el.value;
+	config[property] = selected;
+}
+
+function toggleOption(option, property) {
+	if (property) {
+		config[property][option] = !config[property][option];
+	} else {
+		config[option] = !config[option];
 	}
 }
 
-function toggleControl(id) {
-	config[id] = !config[id];
-}
-
-function setupControls() {
-	// setup basic handler for all clicks
-	document.body.onclick = handleBodyClick;
+function drawCheckboxes(config, property) {
+	var el = document.querySelector('.' + (property || 'options'));
 
 	// convert the list of options into checkboxes
 	var checkboxes = Object.keys(config).filter(function(option) {
 		return typeof config[option] === 'boolean';
 	}).map(function(option) {
 		var checked = config[option] ? ' checked ' : ' ';
-		return '<div class="checkbox-inline"><label><input' + checked + 'type="checkbox" class="option-checkbox" id="' + option + '" />' + option + '</label></div>';
+		return '<div class="checkbox"><label><input' + checked + 'type="checkbox" class="option-checkbox" id="' + option + '" />' + option + '</label></div>';
 	});
 
-	// append the checkboxes to the control list
-	optionsControl.innerHTML = checkboxes.join('');
+	el.innerHTML = checkboxes.join('');
+	el.onchange = function(event) {
+		toggleOption(event.target.id, property);
+	}
+
+}
+
+function drawSelectBoxes(config, property) {
+	var el = document.querySelector('.' + property);
+	var select = document.createElement('select');
+	var options = Object.keys(config).filter(function(option) {
+		return typeof config[option] === 'boolean';
+	}).map(function(option) {
+		var selected = config[option] ? ' selected ' : ' ';
+		return '<option ' + selected + ' value="' + option + '">' + option +'</option>';
+	});
+	select.innerHTML = options;
+	select.onchange = function(event) {
+		handleSelectChange(property, event.target);
+	};
+	el.appendChild(select);
+
+	// reset the config to take the currently selected value
+	handleSelectChange(property, select);
+}
+
+function drawVersion() {
+	document.getElementById('version').innerHTML = lib.getVersion();
+}
+
+function setupControls() {
+	drawVersion();
+	drawCheckboxes(config);
+	drawCheckboxes(config.ecmaFeatures, "ecmaFeatures");
+	drawSelectBoxes(config.ecmaVersion, "ecmaVersion");
+	drawSelectBoxes(config.sourceType, "sourceType");
 }
 
 function showError(error) {
@@ -45,7 +80,7 @@ function showError(error) {
 function parseForever() {
 	var ast;
 	try {
-		ast = lib.parse(config);
+		ast = lib.parse(editor.value, config);
 		results.classList.remove('error');
 		results.innerHTML = ast;
 	} catch(error) {
@@ -57,16 +92,19 @@ function parseForever() {
 // set everything up
 setupControls();
 parseForever();
-
 },{"./lib":2,"./parser.config":3}],2:[function(require,module,exports){
 // requires
 var espree = require('espree');
 
-exports.parse = function(config) {
-	var code = editor.value;
+exports.parse = function(code, config) {
 	var ast = espree.parse(code, config); // throws...
 	return JSON.stringify(ast, null, '  ');
 };
+
+exports.getVersion = function() {
+	return espree.version;
+};
+
 },{"espree":"espree"}],3:[function(require,module,exports){
 module.exports = {
 	range: false,
@@ -75,31 +113,19 @@ module.exports = {
 	attachComment: false,
 	tokens: false,
 	tolerant: true,
+	ecmaVersion: {
+		3: false,
+		5: false,
+		6: true
+	},
+	sourceType: {
+		script: false,
+		module: true
+	},
 	ecmaFeatures: {
-		arrowFunctions: true,
-		blockBindings: true,
-		destructuring: true,
-		regexYFlag: true,
-		regexUFlag: true,
-		templateStrings: true,
-		binaryLiterals: true,
-		octalLiterals: true,
-		unicodeCodePointEscapes: true,
-		defaultParams: true,
-		restParams: true,
-		forOf: true,
-		objectLiteralComputedProperties: true,
-		objectLiteralShorthandMethods: true,
-		objectLiteralShorthandProperties: true,
-		objectLiteralDuplicateProperties: true,
-		generators: true,
-		spread: true,
-		superInFunctions: true,
-		classes: true,
-		newTarget: false,
-		modules: true,
 		jsx: true,
 		globalReturn: true,
+		impliedStrict: false,
 		experimentalObjectRestSpread: true
 	}
 };

--- a/js/app/parser/lib.js
+++ b/js/app/parser/lib.js
@@ -1,8 +1,11 @@
 // requires
 var espree = require('espree');
 
-exports.parse = function(config) {
-	var code = editor.value;
+exports.parse = function(code, config) {
 	var ast = espree.parse(code, config); // throws...
 	return JSON.stringify(ast, null, '  ');
+};
+
+exports.getVersion = function() {
+	return espree.version;
 };

--- a/js/app/parser/parser.config.js
+++ b/js/app/parser/parser.config.js
@@ -5,31 +5,19 @@ module.exports = {
 	attachComment: false,
 	tokens: false,
 	tolerant: true,
+	ecmaVersion: {
+		3: false,
+		5: false,
+		6: true
+	},
+	sourceType: {
+		script: false,
+		module: true
+	},
 	ecmaFeatures: {
-		arrowFunctions: true,
-		blockBindings: true,
-		destructuring: true,
-		regexYFlag: true,
-		regexUFlag: true,
-		templateStrings: true,
-		binaryLiterals: true,
-		octalLiterals: true,
-		unicodeCodePointEscapes: true,
-		defaultParams: true,
-		restParams: true,
-		forOf: true,
-		objectLiteralComputedProperties: true,
-		objectLiteralShorthandMethods: true,
-		objectLiteralShorthandProperties: true,
-		objectLiteralDuplicateProperties: true,
-		generators: true,
-		spread: true,
-		superInFunctions: true,
-		classes: true,
-		newTarget: false,
-		modules: true,
 		jsx: true,
 		globalReturn: true,
+		impliedStrict: false,
 		experimentalObjectRestSpread: true
 	}
 };

--- a/parser/index.html
+++ b/parser/index.html
@@ -26,15 +26,28 @@ layout: demo
             <div id="configuration" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
                 <div class="panel-body">
                     <div class="row">
-                        <div class="col-md-12">
+                        <div class="col-md-3">
+                            <h3>ECMA Version</h3>
+                            <div class="ecmaVersion select">
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <h3>Source Type</h3>
+                            <div class="sourceType select">
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <h3>ECMA Features</h3>
+                            <div class="ecmaFeatures list">
+                            </div>
+                        </div>
+                        <div class="col-md-2">
                             <h3>Options</h3>
+                            <div class="options list">
+                            </div>
                         </div>
                     </div>
-                    <div class="row options">
-                        <div class="col-md-12 list">
-
-                        </div>
-                    </div>
+                    <div class="row"><div class="col-md-12">Espree version: <span id="version"></span></div></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<img width="1001" alt="screen shot 2016-02-15 at 9 45 23 am" src="https://cloud.githubusercontent.com/assets/246143/13056242/0432d36c-d3c9-11e5-9577-41003739cef7.png">

Fixes everything. Also displays the current Espree Version.  The only issue I have now is why does the `eslint` in this repo include the outdated `espree` version `2.2.5`? Other than that everything seems to work fine!