### PR TITLE
link to ESLint repo on source code page.

### DIFF
--- a/docs/developer-guide/source-code.md
+++ b/docs/developer-guide/source-code.md
@@ -5,7 +5,7 @@ layout: doc
 
 # Source Code
 
-ESLint is hosted at [GitHub](http://www.github.com) and uses [Git](http://git-scm.com/) for source control. In order to obtain the source code, you must first install Git on your system. Instructions for installing and setting up Git can be found at [http://help.github.com/set-up-git-redirect](http://help.github.com/set-up-git-redirect).
+ESLint is hosted at [GitHub](https://github.com/eslint/eslint) and uses [Git](http://git-scm.com/) for source control. In order to obtain the source code, you must first install Git on your system. Instructions for installing and setting up Git can be found at [http://help.github.com/set-up-git-redirect](http://help.github.com/set-up-git-redirect).
 
 If you simply want to create a local copy of the source to play with, you can clone the main repository using this command:
 


### PR DESCRIPTION
The Source code page has a link to github in it's opening sentence:

`ESLint is hosted at GitHub...`

but originally the link simply opened up github.com, which is not as useful or relevant than pointing to the actual __source code__ on github, since this is the "source code" page. So this PR aims to update that link to the actual source code. 

**Thanks for all the awesome work you do!!** I :heart: ESLint.


 

