### PR TITLE
Docs: fix wrong URLs in feed.

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,8 +13,8 @@ layout: none
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}/{{ post.url }}</link>
-        <guid isPermaLink="true">{{ site.url }}/{{ post.url }}</guid>
+        <link>{{ site.url }}{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
       </item>
     {% endfor %}
   </channel>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1937871/13066002/67d2dfc0-d4a5-11e5-9eeb-fb38ff2c0b8a.png)

Feed has extra slashes.