### PR TITLE
Docs: Fix broken link in Governance

### DIFF
--- a/docs/developer-guide/governance.md
+++ b/docs/developer-guide/governance.md
@@ -25,7 +25,7 @@ As Contributors gain experience and familiarity with the project, their profile 
 
 ### Committers
 
-Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](contributing.html).
+Committers are community members who have shown that they are committed to the continued development of the project through ongoing engagement with the community. Committers are given push access to the project's GitHub repos and must abide by the project's [Contribution Guidelines](contributing).
 
 Committers:
 


### PR DESCRIPTION
Previously, the Contribution Guidelines link had a leftover `.html` extension, but that's now an index page.