### PR TITLE
Proposal: Increase scope of committership

### DIFF
--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -31,11 +31,10 @@ Committers:
 
 * Are expected to work on public branches of the source repository and submit pull requests from that branch to the master branch.
 * Are expected to delete their public branches when they are no longer necessary.
-* May submit small changes (documentation updates, changes to tests or code comments, configuration changes) without pull requests.
-* Must submit pull requests for any non-trivial changes.
+* Must submit pull requests for all changes.
 * Have their work reviewed by Reviewers before acceptance into the repository.
-* May label issues as they are submitted ("accepted" label should only be added for bugs, and only if the committer verified the bug as valid).
-* May close issues if they are duplicates of already resolved issues.
+* May label and close issues (see [Managing Issues](issues.html))
+* May merge some pull requests (see [Managing Pull Requests](pullrequests.html))
 
 To become a Committer:
 

--- a/docs/maintainer-guide/issues.md
+++ b/docs/maintainer-guide/issues.md
@@ -52,13 +52,15 @@ The steps for triaging an issue are:
 1. Next steps:
   * **Questions:** answer the question and close the issue when the conversation is over.
   * **Bugs:** if you can verify the bug, add the "accepted" label and ask if they would like to submit a pull request.
-  * **New Rules:** if you are willing to champion the rule (meaning you believe it should be included in ESLint core), then add a comment saying you will champion the rule and add an "accepted" label. As the champion, it's your job to guide the rule creation process until it's complete, so only champion a rule that you have time to implement or help another contributor implement it.
+  * **New Rules:** if you are willing to champion the rule (meaning you believe it should be included in ESLint core), then add a comment saying you will champion the issue and add an "accepted" label. As the champion, it's your job to guide the rule creation process until it's complete, so only champion a rule that you have time to implement or help another contributor implement.
+  * **Rule Changes:** if you are willing to champion the change, and the change would not be breaking (requiring a major version increment), then add a comment saying that you will champion the issue and add an "accepted" label. As with new rules, the champion is expected to guide the change through to completion.
+  * **Breaking Changes:** if you suspect or can verify that a change would be breaking, label it as "Breaking".
   * **Duplicates:** if you can verify the issue is a duplicate, add a comment mentioning the duplicate issue (such as, "Duplicate of #1234") and close the issue.
 1. Regardless of the above, always leave a comment. Don't just add labels, engage with the person who opened the issue by asking a question (request more information if necessary) or stating your opinion of the issue. If it's a verified bug, ask if the user would like to submit a pull request.
 
-**Note:** Don't add an "accepted" label to an issue unless it's a bug that you've been able to reproduce and verify (you're sure it's a bug) or a new rule that you're championing. The "accepted" label will be added by a project lead if it's appropriate for the roadmap.
+**Note:** Don't add an "accepted" label to an issue unless it's a bug that you've been able to reproduce and verify (you're sure it's a bug), a new rule that you're championing, or a rule change that you're championing. The "accepted" label will be added to other issues by a project lead if it's appropriate for the roadmap.
 
-## Evaluating Features and Enhancements (Project Leads Only)
+## Evaluating Core Features and Enhancements (Project Leads Only)
 
 If you're a project lead, then you'll need to evaluate incoming requests for inclusion in the formal roadmap. You should label an issue as "accepted" when all of the following are true:
 

--- a/docs/maintainer-guide/pullrequests.md
+++ b/docs/maintainer-guide/pullrequests.md
@@ -38,17 +38,30 @@ Once the bot checks have been satisfied, you check the following:
 
 **Note:** If you are a team member and you've left a comment on the pull request, please follow up to verify that your comments have been addressed.
 
+## Who Can Merge a Pull Request
+
+Reviewers and committers may merge pull requests, depending on the contents of the pull request.
+
+Committers may merge a pull request if it is a non-breaking change and is:
+
+1. A documentation change
+1. A bug fix (for either rules or core)
+1. A dependency upgrade
+1. Related to the build system
+
+Reviewers may merge all pull requests, including those that committers may merge.
+
 ## When to Merge a Pull Request
 
-If you are a reviewer, then you can click the "Merge" button on a pull request to merge the changes. Before merging a pull request, verify that:
+We use the "Merge" button to merge requests into the repository. Before merging a pull request, verify that:
 
-1. All comments have been addressed.
-1. Any team members who made comments have verified that their concerns were addressed.
-1. All automated tests are passing (never merge a pull request with failing tests).
-
-Ideally, the first reviewer to comment on the pull request should be the one to merge it. However, if you don't feel comfortable doing so for any reason, just leave a comment saying "LGTM but would like someone else to verify".
+1. All comments have been addressed
+1. Any team members who made comments have verified that their concerns were addressed
+1. All automated tests are passing (never merge a pull request with failing tests)
 
 Be sure to say thank you to the submitter before merging, especially if they put a lot of work into the pull request.
+
+**Note:** You should not merge your own pull request unless you're received feedback from at least one other team member.
 
 ## When to Close a Pull Request
 


### PR DESCRIPTION
Recently, the ESLint Reviewers concluded that it would be good to give ESLint Committers more authority in the project. This pull request proposes:

1. Committers should be allowed to merge some pull requests (bug fixes, docs, build-related, upgrades) on their own so long as they are non-breaking.
1. Committers should be allowed to label an issue as "accepted" if it is a bug fix, a new rule, or a non-breaking change to an existing rule. I think this change is good because it didn't make sense to allow Committers to accept new rules but not changes to existing rules.

Please let me know your thoughts. @eslint/eslint-team 


