### PR TITLE
Docs: Point to gitter chat as well as mailing list in change request docs

### DIFF
--- a/docs/developer-guide/contributing/changes.md
+++ b/docs/developer-guide/contributing/changes.md
@@ -19,4 +19,4 @@ If you're requesting a change to a rule, it's helpful to include this informatio
 
 Please include as much detail as possible to help us properly address your issue. If we need to triage issues and constantly ask people for more detail, that's time taken away from actually fixing issues. Help us be as efficient as possible by including a lot of detail in your issues.
 
-**Note:** If you just have a question that won't necessarily result in a change to ESLint, such as asking how something works or how to contribute, please use the [mailing list](https://groups.google.com/group/eslint) instead of filing an issue.
+**Note:** If you just have a question that won't necessarily result in a change to ESLint, such as asking how something works or how to contribute, please use the [mailing list](https://groups.google.com/group/eslint) or [chat](https://gitter.im/eslint/eslint) instead of filing an issue.


### PR DESCRIPTION
Feel free to close if you would prefer people go to the mailing list, but I think one or two other places put the mailing list and chat on the same level, as "media we would prefer that people use to ask questions".