### PR TITLE
Update Algolia config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'jekyll', '~> 3.0.0'
 
 group :jekyll_plugins do
-  gem 'algoliasearch-jekyll', '~> 0.5.1'
+  gem 'algoliasearch-jekyll', '~> 0.7.0'
   gem 'jekyll-sitemap', '~> 0.10.0'
   gem 'jekyll-redirect-from', '~> 0.9.1'
 end


### PR DESCRIPTION

Fixes #216

Seems likes the move to kramdown caused the root issue. Kramdown seems
to have trouble converting markdown that looks like this:

```
<!-- HTML comment -->
# Title
```

Instead of creating the `h1`, it kept the `#`. Adding a newline
between the comment and the title fixes the issue, but I actually
fixed it in another way.

I realize that the current setting was indexing every rule, for every
version. I felt this was not the best way to do it, as this requires
blacklisting versions everytime you would add a new one. Instead,
I chose to only index the rules in `/docs/rules`, without any version
specified.

Turns out that the files in this directory do not have the HTML
comment bug..

I also updated the underlying gem and fixed a edge-case with the Rule
index page.

In the end it decreased the number of records from ~9300 to ~5200, by
removing all duplicate rules of various versions.
