### PR TITLE
Trailing comma on example would causes Parse error

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -42,7 +42,7 @@ Here's an example `.eslintrc.json` file:
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": true
-        },
+        }
     },
     "rules": {
         "semi": 2


### PR DESCRIPTION
> eslint js/behavior.js

```
Cannot read config file: /www/.eslintrc.json
Error: Unexpected token }
SyntaxError: Cannot read config file: /www/.eslintrc.json
Error: Unexpected token }
    at Object.parse (native)
    at loadJSONConfigFile (/usr/local/lib/node_modules/eslint/lib/config/config-file.js:117:21)
    at loadConfigFile (/usr/local/lib/node_modules/eslint/lib/config/config-file.js:210:26)
    at Object.load (/usr/local/lib/node_modules/eslint/lib/config/config-file.js:437:18)
    at loadConfig (/usr/local/lib/node_modules/eslint/lib/config.js:67:33)
    at getLocalConfig (/usr/local/lib/node_modules/eslint/lib/config.js:129:23)
    at Config.getConfig (/usr/local/lib/node_modules/eslint/lib/config.js:223:22)
    at processText (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:155:27)
    at processFile (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:227:18)
    at executeOnFile (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:603:23)
```