### PR TITLE
Docs: Style prerequisite to display wrench icon in fixable rule pages

### DIFF
--- a/styles/overrides.css
+++ b/styles/overrides.css
@@ -35,3 +35,7 @@ h6:target:before {
   margin: 0 2px;
 }
 
+/* wrench icon at the beginning of the first paragraph in the doc for a fixable rule */
+h1 + p > span.glyphicon:first-child {
+  margin-right: 1em;
+}


### PR DESCRIPTION
This style rule displays a wrench icon in the left margin of the page for a fixable rule.

It is a prerequisite to the following change from/to in 30 fixable rule pages:

**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
(fixable)This rule is automatically fixable using the `--fix` flag on the command line.

We will also move that paragraph immediately after main heading.

The following comments have pictures of the intended layout. The pictures include other future changes to show how each small step moves toward a bigger goal.

P.S. It sounds like a game of Clue: ESLint with the wrench in the margin.