### PR TITLE
Revert Gemfile change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll', '~> 3.0.0'
 
 group :jekyll_plugins do
   gem 'algoliasearch-jekyll', '~> 0.7.0'


### PR DESCRIPTION
It seems like after the last Gemfile change, the Algolia search went a bit crazy. Maybe reverting to this will fix it.