### PR TITLE
Docs: Replacement rules for examples of additional code

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -3,7 +3,19 @@
 <main class="doc">
   <article class="container">
     {% include ad.html %}
-    {{ content | replace: '(recommended)', '<span title="recommended" aria-label="recommended" class="glyphicon glyphicon-ok"></span>' | replace: '<p>(fixable) ', '<p class="fixable">' | replace: '(fixable)', '<span title="fixable" aria-label="fixable" class="glyphicon glyphicon-wrench"></span>' | replace: '<p>Examples of <strong>incorrect</strong> code', '<p class="incorrect">Examples of <strong>incorrect</strong> code' | replace: '<p>Examples of <strong>correct</strong> code', '<p class="correct">Examples of <strong>correct</strong> code' | replace: '<p>Example of <strong>incorrect</strong> code', '<p class="incorrect">Example of <strong>incorrect</strong> code' | replace: '<p>Example of <strong>correct</strong> code', '<p class="correct">Example of <strong>correct</strong> code' }}
+    {{ content
+      | replace: '<p>Examples of <strong>incorrect</strong> code', '<p class="incorrect">Examples of <strong>incorrect</strong> code'
+      | replace: '<p>Example of <strong>incorrect</strong> code', '<p class="incorrect">Example of <strong>incorrect</strong> code'
+      | replace: '<p>Examples of additional <strong>incorrect</strong> code', '<p class="incorrect">Examples of additional <strong>incorrect</strong> code'
+      | replace: '<p>Example of additional <strong>incorrect</strong> code', '<p class="incorrect">Example of additional <strong>incorrect</strong> code'
+      | replace: '<p>Examples of <strong>correct</strong> code', '<p class="correct">Examples of <strong>correct</strong> code'
+      | replace: '<p>Example of <strong>correct</strong> code', '<p class="correct">Example of <strong>correct</strong> code'
+      | replace: '<p>Examples of additional <strong>correct</strong> code', '<p class="correct">Examples of additional <strong>correct</strong> code'
+      | replace: '<p>Example of additional <strong>correct</strong> code', '<p class="correct">Example of additional <strong>correct</strong> code'
+      | replace: '<p>(fixable) ', '<p class="fixable">'
+      | replace: '(recommended)', '<span title="recommended" aria-label="recommended" class="glyphicon glyphicon-ok"></span>'
+      | replace: '(fixable)', '<span title="fixable" aria-label="fixable" class="glyphicon glyphicon-wrench"></span>'
+    }}
   </article>
 </main>
 {% include footer.html %}


### PR DESCRIPTION
As discussed in https://github.com/eslint/eslint/pull/5807#issuecomment-207621143 and https://github.com/eslint/eslint/pull/5807#issuecomment-207689759, and then added to guidelines in https://github.com/eslint/eslint/issues/5446#issuecomment-191306528, the word additional makes it explicit that code is the same as or related to a preceding example.

This change will add the class which displays icon and background-color in recently edited rule docs:
* allowEmptyCatch option in no-empty
* allowArrowFunctions option in func-style
* exceptions option in id-length