### PR TITLE
Chore: Remove old unused docs

### DIFF
--- a/docs/command-line-interface/index.html
+++ b/docs/command-line-interface/index.html
@@ -1,6 +1,0 @@
----
-layout: redirect
-sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
----
-

--- a/docs/configuring/index.html
+++ b/docs/configuring/index.html
@@ -1,6 +1,0 @@
----
-layout: redirect
-sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
----
-


### PR DESCRIPTION
I'm pretty sure we don't link to these anywhere at this point (duplicates are in `user-guide`).