### PR TITLE
Docs: Add link to gitter chat room in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,7 @@
           <li><a href="https://groups.google.com/group/eslint">Mailing List</a></li>
           <li><a href="https://github.com/eslint/eslint">GitHub</a></li>
           <li><a href="https://twitter.com/geteslint">Twitter</a></li>
+          <li><a href="https://gitter.im/eslint/eslint">Chat Room</a></li>
           <li>Copyright jQuery Foundation and other contributors, <a href="https://jquery.org">https://jquery.org/</a></li>
         </ul>
       </footer>


### PR DESCRIPTION
I thought it'd be nice to add a link to the gitter chat room to the footer since we're all pretty active there.