### PR TITLE
Docs: Fix a broken link in 3.6 blog post

### DIFF
--- a/_posts/2016-09-23-eslint-v3.6.0-released.md
+++ b/_posts/2016-09-23-eslint-v3.6.0-released.md
@@ -29,7 +29,7 @@ With this release, we support ECMA2017 syantax natively. To activate ECMA2017 pa
 #### Rules enhanced to support ECMA2017
 
 * [`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops)
-* [`no-extra-paren`](http://eslint.org/docs/rules/no-extra-paren)
+* [`no-extra-parens`](http://eslint.org/docs/rules/no-extra-parens)
 * [`keyword-spacing`](http://eslint.org/docs/rules/keyword-spacing)
 * [`arrow-parens`](http://eslint.org/docs/rules/arrow-parens)
 * [`prefer-arrow-callback`](http://eslint.org/docs/rules/prefer-arrow-callback)


### PR DESCRIPTION
It currently links to [`no-extra-paren`](http://eslint.org/docs/rules/no-extra-paren), which is a 404. It should link to [`no-extra-parens`](http://eslint.org/docs/rules/no-extra-parens) instead.