### PR TITLE
Docs: ECMA2017 → ES2017

### DIFF
--- a/_posts/2016-09-23-eslint-v3.6.0-released.md
+++ b/_posts/2016-09-23-eslint-v3.6.0-released.md
@@ -13,9 +13,9 @@ We just pushed ESLint v3.6.0, which is a minor release upgrade of ESLint. This r
 
 This is a summary of the major changes you need to know about for this version of ESLint.
 
-### Support for ECMA2017
+### Support for ES2017
 
-With this release, we support ECMA2017 syantax natively. To activate ECMA2017 parser option, you need to update parser option (in your `.eslintrc.*` file).
+With this release, we support ES2017 syantax natively. To activate ES2017 parser option, you need to update parser option (in your `.eslintrc.*` file).
 
 ```js
 {
@@ -26,7 +26,7 @@ With this release, we support ECMA2017 syantax natively. To activate ECMA2017 pa
 }
 ```
 
-#### Rules enhanced to support ECMA2017
+#### Rules enhanced to support ES2017
 
 * [`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops)
 * [`no-extra-parens`](http://eslint.org/docs/rules/no-extra-parens)


### PR DESCRIPTION
The specification of ECMAScript® is ECMA-262. So I'm confused a bit in the ECMA2017 notation.
This PR changes ECMA2017 to ES2017.