### PR TITLE
Fix: fix incorrect link in 3.7.0 release.

### DIFF
--- a/_posts/2016-09-30-eslint-v3.7.0-released.md
+++ b/_posts/2016-09-30-eslint-v3.7.0-released.md
@@ -19,7 +19,7 @@ In addition to linting code, many of the rules can automatically fix errors usin
 
 * [prefer-numeric-literals](http://eslint.org/docs/rules/prefer-numeric-literals)
 * [no-undef-init](http://eslint.org/docs/rules/no-undef-init)
-* [no-useless-computed-key](http://eslint.org/docs/rules/no-undef-init)
+* [no-useless-computed-key](http://eslint.org/docs/rules/no-useless-computed-key)
 * [lines-around-directive](http://eslint.org/docs/rules/lines-around-directive)
 * [wrap-iife](http://eslint.org/docs/rules/wrap-iife)
 * [dot-location](http://eslint.org/docs/rules/dot-location)


### PR DESCRIPTION
The link for `no-useless-computed-key` pointed to the rule page for `no-undef-init`.