### PR TITLE
Chore: add `start` to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository runs on GitHub pages through Jekyll. To setup a local environmen
 Once you have setup a local environment, you can run a copy of the website locally using this command:
 
 ```
-$ bundle exec jekyll serve --watch
+$ npm start
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "browserify -x espree js/app/parser/index.js > js/app/parser/index.built.js",
+    "start": "bundle exec jekyll serve --watch --incremental",
     "test": "echo \"Error: no test specified\" && exit 1",
     "less": "lessc styles/less/main.less styles/main.css -x --source-map=styles/main.css.map"
   },


### PR DESCRIPTION
I find myself constantly having to look-up the `jekyll` command to fire up the local server for the website. I thought having an npm script for it would be a good idea.