### PR TITLE
Docs: redirect old CLA page to JS foundation CLA (fixes #254)

### DIFF
--- a/cla/index.md
+++ b/cla/index.md
@@ -1,18 +1,5 @@
 ---
 title: ESLint Contributor License Agreement
 layout: doc
+redirect_to: "https://js.foundation/CLA/"
 ---
-
-# Contributor License Agreement (CLA)
-
-A CLA is a document that specifies how a project is allowed to use your code. We've put a lot of work into creating a CLA that is simple, effective, and as clear as possible so that it doesn't disrupt contributions to ESLint.
-
-When you make a contribution to the ESLint project, you agree:
-
-1. The code you wrote is your original work (you own the copyright) or you otherwise have the right to submit the work.
-1. To grant the ESLint project a nonexclusive, irrevocable license to use your submitted code in any way.
-1. You are capable of granting these rights for the contribution.
-
-Please electronically sign by filling out the form below:
-
-<iframe src="https://docs.google.com/forms/d/170pw6QjVHPNMDFpTTL0M2jaKZr-KMHI4PNx67eGW8WA/viewform?embedded=true" width="760" height="600" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>


### PR DESCRIPTION
**What changes did you make? (Give an overview)**
Made our old CLA page redirect to the JS foundation CLA page instead.

**Is there anything you'd like reviewers to focus on?**
I think not :)