### PR TITLE
Docs: add links to top-level sections in the menu (fixes #303)

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -21,7 +21,7 @@
     <nav id="eslint-navbar" class="collapse navbar-collapse eslint-navbar">
       <ul class="nav navbar-nav navbar-right">
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
+          <a href="/docs/user-guide" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
             <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
@@ -34,7 +34,7 @@
           </ul>
         </li>
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Developer guide<span class="caret"></span></a>
+          <a href="/docs/developer-guide" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Developer guide<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="/docs/developer-guide/architecture">Architecture</a></li>
             <li><a href="/docs/developer-guide/contributing">Contributing</a></li>
@@ -50,7 +50,7 @@
         </li>
         <li><a href="/blog/">Blog</a></li>
         <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Demo<span class="caret"></span></a>
+          <a href="/demo" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Demo<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
             <li><a href="/demo/">ESLint Demo</a></li>
             <li><a href="/parser/">Espree Demo</a></li>


### PR DESCRIPTION
**What changes did you make? (Give an overview)**
Closes #303. For each dropdown in the menu, I added a link to its respective top-level section page. That way, if for any reason the scripts failed to load, the user will still be able to navigate to all the sub-sections.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.

