### PR TITLE
Docs: better default for deprecated rules with no replacement

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -65,7 +65,11 @@ The `--fix` option on the [command line](../user-guide/command-line-interface#fi
 <tr>
 <td markdown="1">[{{rule.name}}]({{rule.name}})
 </td>
+{% if rule.replacedBy.size > 0 %}
 <td class="replaced-by" markdown="1">{% for replaced in rule.replacedBy %}[{{replaced}}]({{replaced}}){% endfor %}
+{% else %}
+<td class="replaced-by" markdown="1"><p class="text-muted">(no replacement)</p>
+{% endif %}
 </td>
 </tr>
 {% endfor %}
@@ -99,7 +103,11 @@ The `--fix` option on the [command line](../user-guide/command-line-interface#fi
 <tr>
 <td markdown="1">[{{rule.removed}}]({{rule.removed}})
 </td>
+{% if rule.replacedBy.size > 0 %}
 <td class="replaced-by" markdown="1">{% for replaced in rule.replacedBy %}[{{replaced}}]({{replaced}}){% endfor %}
+{% else %}
+<td class="replaced-by" markdown="1"><p class="text-muted">(no replacement)</p>
+{% endif %}
 </td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
**What is the purpose of this pull request?**
Visually improve the way deprecated rules that have no replacement would look like in the "Deprecated" section of the rules list. With this change, the current list would look like this:

![screenshot 2016-10-31 17 30 43](https://cloud.githubusercontent.com/assets/626038/19862368/442786e6-9f90-11e6-90ae-0a7218a30c0d.png)

**What changes did you make? (Give an overview)**
Changed the rules list template to treat rules with an empty `replacedBy` property differently.

**Is there anything you'd like reviewers to focus on?**
We could also just leave the "replaced by" column empty instead, but I thought it looks like the table was a bit broken.. with this change, there is a small visual cue that the rule intentionally does not have any replacements.


