### PR TITLE
Docs: fix CLA page redirect URL

### DIFF
--- a/cla/index.md
+++ b/cla/index.md
@@ -1,5 +1,5 @@
 ---
 title: ESLint Contributor License Agreement
 layout: doc
-redirect_to: "https://js.foundation/CLA/"
+redirect_to: "https://cla.js.foundation/eslint/eslint"
 ---


### PR DESCRIPTION
**What changes did you make? (Give an overview)**
Updated the redirect of the old CLA page to point to the new jsfoundation URL. Refs https://github.com/eslint/eslint/issues/7558

**Is there anything you'd like reviewers to focus on?**
Not really, I think.

