### PR TITLE
Adding formatter pages to menus

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -26,6 +26,7 @@
             <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
             <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
             <li><a href="/docs/rules/">Rules</a></li>
+            <li><a href="/docs/user-guide/formatters">Formatters</a></li>
             <li class="divider"></li>
             <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-2.0.0">Migrating to v2.0.0</a></li>
@@ -43,6 +44,7 @@
             <li><a href="/docs/developer-guide/unit-tests">Run the Unit Tests</a></li>
             <li><a href="/docs/developer-guide/working-with-rules">Working with Rules</a></li>
             <li><a href="/docs/developer-guide/working-with-plugins">Working with Plugins</a></li>
+            <li><a href="/docs/developer-guide/working-with-custom-formatters">Working with Custom Formatters</a></li>
             <li><a href="/docs/developer-guide/shareable-configs">Shareable Configs</a></li>
             <li><a href="/docs/developer-guide/nodejs-api">Node.js API</a></li>
             <li><a href="/docs/maintainer-guide">Maintainer guide</a></li>


### PR DESCRIPTION
Adding "Formatters" to user guide menu and "Working with Custom Formatters" to developer guide menu

No changes have been made to the individual pages; those can be done separately.

NOTE: I haven't had a chance to install Jekyll on my (Windows) machine, so this is untested. But the HTML is pretty straightforward, so...