### PR TITLE
Docs: include a link to the JSCS migration guide in the header dropdown

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -31,6 +31,7 @@
             <li><a href="/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-2.0.0">Migrating to v2.0.0</a></li>
             <li><a href="/docs/user-guide/migrating-to-3.0.0">Migrating to v3.0.0</a></li>
+            <li><a href="/docs/user-guide/migrating-from-jscs">Migrating from JSCS</a></li>
             <li><a href="/docs/user-guide/integrations">Integrations</a></li>
           </ul>
         </li>


### PR DESCRIPTION
We created a JSCS migration guide awhile ago, but I don't think we linked to it from anywhere, so JSCS users might not realize it exists.