### PR TITLE
Remove reference to deleted rule

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -212,7 +212,7 @@ class Foo {
 
 ## When Not To Use It
 
-You can turn this rule off if you are not concerned with the consistency of spacing before blocks or if you are using the `space-after-keywords` rule set to `"never"`.
+You can turn this rule off if you are not concerned with the consistency of spacing before blocks.
 
 ## Related Rules
 


### PR DESCRIPTION
`space-after-keywords` appears as deleted in the docs and it's confusing to reference it.