### PR TITLE
Add ESLint tutorial screenshot and link

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -12,6 +12,10 @@ ESLint is a tool for identifying and reporting on patterns found in ECMAScript/J
 * ESLint uses an AST to evaluate patterns in code.
 * ESLint is completely pluggable, every single rule is a plugin and you can add more at runtime.
 
+## Getting Started Tutorial
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/hppJw2REb8g?rel=0" frameborder="0" allowfullscreen></iframe>
+*Why ESLint* @0:00, *Installing and using ESLint* @2:20.  <a href="https://www.pluralsight.com/courses/eslint-better-code-quality" target="_blank">Full ESLint Course at Pluralsight</a>
+
 ## Installation and Usage
 
 There are two ways to install ESLint: globally and locally.


### PR DESCRIPTION
I recently published a Pluralsight course on ESLint: https://www.pluralsight.com/courses/eslint-better-code-quality. 

Adding a link to a short youtube video here. Prior context here: https://github.com/eslint/eslint.github.io/issues/324

@ilyavolodin Let me know how this looks. I can drop this line if needed (since this links to youtube anyway):
```<a href="https://www.pluralsight.com/courses/eslint-better-code-quality" target="_blank">Full ESLint Course at Pluralsight</a>``` 