### PR TITLE
Docs: Add "Getting Started" link to User Guid menu

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -23,6 +23,7 @@
         <li class="dropdown">
           <a href="/docs/user-guide" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">User guide<span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
+            <li><a href="/docs/user-guide/getting-started">Getting Started</a></li>
             <li><a href="/docs/user-guide/configuring">Configuring ESLint</a></li>
             <li><a href="/docs/user-guide/command-line-interface">Command Line Interface</a></li>
             <li><a href="/docs/rules/">Rules</a></li>


### PR DESCRIPTION
Given how important this page is for newcomers, we should ensure ease of access by including it in the User Guide dropdown. (Currently, it's linked to via a big button on the homepage, but the homepage doesn't have much other useful information and it's not hard to envision someone jumping straight to Configuring or the rules index.)