### PR TITLE
Apply documentation fixes from ESLint repo

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -173,7 +173,7 @@ Output object from this method:
 ```js
 {
     fixed: true,
-    text: "var foo;",
+    output: "var foo;",
     messages: []
 }
 ```
@@ -181,7 +181,7 @@ Output object from this method:
 The information available is:
 
 * `fixed` - True, if the code was fixed.
-* `text` - Fixed code text (might be the same as input if no fixes were applied).
+* `output` - Fixed code text (might be the same as input if no fixes were applied).
 * `messages` - Collection of all messages for the given code (It has the same information as explained above under `verify` block).
 
 ## linter

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -74,7 +74,7 @@ foo > bar ?
 Examples of **incorrect** code for this rule with the `"always-multiline"` option:
 
 ```js
-/*eslint multiline-ternary: ["error", "always"]*/
+/*eslint multiline-ternary: ["error", "always-multiline"]*/
 
 foo > bar ? value1 :
     value2;
@@ -89,7 +89,7 @@ foo > bar &&
 Examples of **correct** code for this rule with the `"always-multiline"` option:
 
 ```js
-/*eslint multiline-ternary: ["error", "always"]*/
+/*eslint multiline-ternary: ["error", "always-multiline"]*/
 
 foo > bar ? value1 : value2;
 

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -12,17 +12,23 @@ In Node.js, most I/O is done through asynchronous methods. However, there are of
 
 This rule is aimed at preventing synchronous methods from being called in Node.js. It looks specifically for the method suffix "`Sync`" (as is the convention with Node.js operations).
 
-Examples of **incorrect** code for this rule:
+## Options
+
+This rule has an optional object option `{ allowAtRootLevel: <boolean> }`, which determines whether synchronous methods should be allowed at the top level of a file, outside of any functions. This option defaults to `false`.
+
+Examples of **incorrect** code for this rule with the default `{ allowAtRootLevel: false }` option:
 
 ```js
 /*eslint no-sync: "error"*/
 
 fs.existsSync(somePath);
 
-var contents = fs.readFileSync(somePath).toString();
+function foo() {
+  var contents = fs.readFileSync(somePath).toString();
+}
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule with the default `{ allowAtRootLevel: false }` option:
 
 ```js
 /*eslint no-sync: "error"*/
@@ -34,9 +40,29 @@ async(function() {
 });
 ```
 
+Examples of **incorrect** code for this rule with the `{ allowAtRootLevel: true }` option
+
+```js
+/*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
+
+function foo() {
+  var contents = fs.readFileSync(somePath).toString();
+}
+
+var bar = baz => fs.readFileSync(qux);
+```
+
+Examples of **correct** code for this rule with the `{ allowAtRootLevel: true }` option
+
+```js
+/*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
+
+fs.readFileSync(somePath).toString();
+```
+
 ## When Not To Use It
 
-If you want to allow synchronous operations in your script.
+If you want to allow synchronous operations in your script, do not enable this rule.
 
 ## Version
 


### PR DESCRIPTION
This adds the documentation fixes from https://github.com/eslint/eslint/commit/1a89e1c53e543b483cb7a859a71f7917204cea18, https://github.com/eslint/eslint/commit/45f8cd9e06e9e5118b4980afcfcd4c6e0978b574, and https://github.com/eslint/eslint/commit/3c1dd6d8d3391b3568d6452e11d3d1336c629d5e. This should hopefully avoid confusion for users in the next couple weeks, in case we don't end up doing a patch release for 4.2.0.