### PR TITLE
Fix mixed content in demo

### DIFF
--- a/_layouts/demo.html
+++ b/_layouts/demo.html
@@ -1,6 +1,6 @@
 {% include header.html %}
 {% include menu.html %}
-<link rel="stylesheet" property="stylesheet" type="text/css" href="http://eclipse.org/orion/editor/releases/current/built-editor.css" />
+<link rel="stylesheet" property="stylesheet" type="text/css" href="https://eclipse.org/orion/editor/releases/current/built-editor.css" />
 <main class="container">
     {{ content }}
 </main>

--- a/js/app/demo/requireConfig.js
+++ b/js/app/demo/requireConfig.js
@@ -5,7 +5,7 @@ requirejs.config({
         'text': '../../vendor/text',
         'JSXTransformer': '../../vendor/JSXTransformer',
         'jsx': '../../vendor/jsx',
-        'orion': 'http://eclipse.org/orion/editor/releases/current/built-editor-amd.min',
+        'orion': 'https://eclipse.org/orion/editor/releases/current/built-editor-amd.min',
         'eslint': '../eslint'
     },
     jsx: {


### PR DESCRIPTION
Now that the demo is served over `https`, it was failing to load resources over `http`, causing it to break.