### PR TITLE
Avoid unnecessary empty parens in demo messages for fatal errors

### DIFF
--- a/js/app/demo/message.jsx
+++ b/js/app/demo/message.jsx
@@ -9,7 +9,14 @@ define(['react', 'events'], function(React, events) {
         render: function() {
             return (
                 <div className={"alert alert-" + (this.props.value.fatal || this.props.value.severity === 2 ? "danger" : "warning" )} title={this.props.value.message} onClick={this.handleClick}>
-                    {this.props.value.line}:{this.props.value.column} - {this.props.value.message} (<a href={"http://eslint.org/docs/rules/" + this.props.value.ruleId}>{this.props.value.ruleId}</a>)
+                    {this.props.value.line}:{this.props.value.column} - {this.props.value.message}
+                    {
+                        !this.props.value.fatal && [
+                            ' (',
+                            <a href={"http://eslint.org/docs/rules/" + this.props.value.ruleId}>{this.props.value.ruleId}</a>,
+                            ')'
+                        ]
+                    }
                 </div>
             );
         }

--- a/js/app/demo/message.jsx
+++ b/js/app/demo/message.jsx
@@ -13,7 +13,7 @@ define(['react', 'events'], function(React, events) {
                     {
                         !this.props.value.fatal && [
                             ' (',
-                            <a href={"http://eslint.org/docs/rules/" + this.props.value.ruleId}>{this.props.value.ruleId}</a>,
+                            <a href={"https://eslint.org/docs/rules/" + this.props.value.ruleId}>{this.props.value.ruleId}</a>,
                             ')'
                         ]
                     }


### PR DESCRIPTION
Before:

![](https://i.gyazo.com/b8ac71dc1c7627dc4a614c219749603b.png)

After:

![](https://i.gyazo.com/ec6f6be54e1a1fb3d6097e44711a8e97.png)