### PR TITLE
Refactor Environments component in demo

### DIFF
--- a/js/app/demo/environments.jsx
+++ b/js/app/demo/environments.jsx
@@ -1,49 +1,55 @@
 'use strict';
 
 define(['react'], function(React) {
-    return React.createClass({
-        displayName: 'Environments',
-        getInitialState: function() {
-            return this.props.env;
-        },
-        handleChange: function(env, event) {
-            var environment = {};
-            environment[env] = event.target.checked;
-            this.setState(environment, function() {
-                this.props.onUpdate(this.state);
-            });
-        },
-        renderEnvironments: function() {
-            var env = Object.keys(this.state);
-            var limit = Math.ceil(env.length / 3);
-            var result = [];
-            for (var i = 0; i < 3; i++) {
-                var currentRow = [];
-                for (var j = i * limit, l = (i + 1) * limit; j < l && j < env.length; j++) {
-                    currentRow.push(
-                        <div className="checkbox" key={env[j]}>
-                            <label>
-                                <input type="checkbox" checked={this.state[env[j]]} id={env[j]} onChange={this.handleChange.bind(this, env[j])} />{env[j]}
-                            </label>
+    return function Environments(props) {
+        var envNames = Object.keys(props.env);
+        var columnLimit = 3;
+        var rowLimit = Math.ceil(envNames.length / columnLimit);
+        return (
+            <div className="row">
+                <div className="container">
+                    <div className="row">
+                        <div className="col-md-12">
+                            <h3>Environments</h3>
                         </div>
-                    );
-                }
-                result.push(
-                    <div className="col-md-4" key={i}>
-                        {currentRow}
-                    </div>);
-            }
-            return result;
-        },
-        render: function() {
-            return (
-                <div className="row">
-                    <div className="container">
-                        <div className="row"><div className="col-md-12"><h3>Environments</h3></div></div>
-                        {this.renderEnvironments()}
                     </div>
+                    {
+                        Array(columnLimit).fill().map(function(_, columnIndex) {
+                            return (
+                                <div className="col-md-4" key={columnIndex}>
+                                    {
+                                        envNames.slice(columnIndex * rowLimit, (columnIndex + 1) * rowLimit)
+                                            .map(function(envName) {
+                                                return (
+                                                    <div className="checkbox" key={envName}>
+                                                        <label>
+                                                            <input
+                                                                type="checkbox"
+                                                                checked={props.env[envName]}
+                                                                id={envName}
+                                                                onChange={
+                                                                    function(event) {
+                                                                        var updatedEnv = {};
+                                                                        updatedEnv[envName] = event.target.checked;
+                                                                        props.onUpdate(
+                                                                            Object.assign({}, props.env, updatedEnv)
+                                                                        );
+                                                                    }
+                                                                }
+                                                            />
+                                                            {envName}
+                                                        </label>
+                                                    </div>
+                                                );
+                                            })
+                                    }
+                                </div>
+                            );
+
+                        })
+                    }
                 </div>
-            );
-        }
-    });
+            </div>
+        );
+    };
 });


### PR DESCRIPTION
This refactors the Environments component to do the following:

* Use a functional component rather than state (the state of the Environments component is already stored in the top-level app, so it should be passed down as a prop rather than being duplicated).
* Avoid local mutations when building columns
* Make the number of columns easy to change if necessary