### PR TITLE
Refactor Configuration component to avoid duplicate state

### DIFF
--- a/js/app/demo/configuration.jsx
+++ b/js/app/demo/configuration.jsx
@@ -1,49 +1,50 @@
 'use strict';
 
 define(['react', 'jsx!parserOptions', 'jsx!environments', 'jsx!rulesConfig'], function(React, ParserOptions, Environments, RulesConfig) {
-    return React.createClass({
-        displayName: 'Configuration',
-        getInitialState: function() {
-            return this.props.options;
-        },
-        updateParserOptions: function(options) {
-            this.setState({ parserOptions: options }, function() {
-                this.props.onUpdate(this.state);
-            });
-        },
-        updateRules: function(rules) {
-            this.setState({ rules: rules }, function() {
-                this.props.onUpdate(this.state);
-            });
-        },
-        updateEnvironments: function(env) {
-            this.setState({ env: env }, function() {
-                this.props.onUpdate(this.state);
-            });
-        },
-        render: function() {
-            return (
-                <div className="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                    <div className="panel panel-default">
-                        <div className="panel-heading" role="tab" id="headingOne">
-                            <h4 className="panel-title">
-                                <a data-toggle="collapse" data-parent="#accordion" href="#configuration" aria-expanded="true" aria-controls="configuration">
-                                    Rules Configuration
-                                </a>
-                            </h4>
-                        </div>
-                        <div id="configuration" className="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-                            <div className="panel-body">
-                                <ParserOptions options={this.props.options.parserOptions} onUpdate={this.updateParserOptions} />
-                                <hr />
-                                <Environments env={this.props.options.env} onUpdate={this.updateEnvironments} />
-                                <hr />
-                                <RulesConfig config={this.props.options.rules} docs={this.props.docs} onUpdate={this.updateRules} />
-                            </div>
+    return function Configuration(props) {
+        return (
+            <div className="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+                <div className="panel panel-default">
+                    <div className="panel-heading" role="tab" id="headingOne">
+                        <h4 className="panel-title">
+                            <a data-toggle="collapse" data-parent="#accordion" href="#configuration" aria-expanded="true" aria-controls="configuration">
+                                Rules Configuration
+                            </a>
+                        </h4>
+                    </div>
+                    <div id="configuration" className="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                        <div className="panel-body">
+                            <ParserOptions
+                                options={props.options.parserOptions}
+                                onUpdate={
+                                    function(parserOptions) {
+                                        props.onUpdate(Object.assign({}, props.options, { parserOptions: parserOptions }));
+                                    }
+                                }
+                            />
+                            <hr />
+                            <Environments
+                                env={props.options.env}
+                                onUpdate={
+                                    function(env) {
+                                        props.onUpdate(Object.assign({}, props.options, { env: env }))
+                                    }
+                                }
+                            />
+                            <hr />
+                            <RulesConfig
+                                config={props.options.rules}
+                                docs={props.docs}
+                                onUpdate={
+                                    function(rules) {
+                                        props.onUpdate(Object.assign({}, props.options, { rules: rules }))
+                                    }
+                                }
+                            />
                         </div>
                     </div>
                 </div>
-            );
-        }
-    });
+            </div>
+        );
+    };
 });


### PR DESCRIPTION
This updates the Configuration component to be a functional component (without state), since all the necessary state is stored in the top-level App component.