### PR TITLE
Don't change the URL hash when switching tabs in the demo

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -137,6 +137,7 @@ define(['react', 'jsx!editor', 'jsx!messages', 'jsx!fixedCode', 'jsx!configurati
                                         href="#messages"
                                         aria-controls="messages"
                                         role="tab"
+                                        data-toggle="tab"
                                         onClick={this.disableFixMode}
                                     >
                                         Messages


### PR DESCRIPTION
This fixes an issue where "#messages" would appear at the end of the URL when clicking the Messages tab in the demo. This was happening because we still use `<a>` tags for the tabs, and rely on Bootstrap to override the default click handler.

At some point it would be nice to use `<button>` instead of `<a>` for the tabs, but it seems to be nontrivial to do this while keeping Bootstrap's `nav` styling. This commit updates the navbar to add `data-toggle` to the Messages tab, to avoid changing the URL hash.