### PR TITLE
Allow a permalink to the demo with a given piece of code and config

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -86,12 +86,7 @@ define(['react', 'jsx!editor', 'jsx!messages', 'jsx!fixedCode', 'jsx!configurati
                     parserOptions: {
                         ecmaVersion: 5,
                         sourceType: 'script',
-                        ecmaFeatures: {
-                            jsx: false,
-                            globalReturn: false,
-                            impliedStrict: false,
-                            experimentalObjectRestSpread: false
-                        }
+                        ecmaFeatures: {}
                     },
                     rules: (function() {
                         var result = {};

--- a/js/app/demo/configuration.jsx
+++ b/js/app/demo/configuration.jsx
@@ -25,6 +25,7 @@ define(['react', 'jsx!parserOptions', 'jsx!environments', 'jsx!rulesConfig'], fu
                             <hr />
                             <Environments
                                 env={props.options.env}
+                                envNames={props.envNames}
                                 onUpdate={
                                     function(env) {
                                         props.onUpdate(Object.assign({}, props.options, { env: env }))
@@ -34,6 +35,7 @@ define(['react', 'jsx!parserOptions', 'jsx!environments', 'jsx!rulesConfig'], fu
                             <hr />
                             <RulesConfig
                                 config={props.options.rules}
+                                ruleNames={props.ruleNames}
                                 docs={props.docs}
                                 onUpdate={
                                     function(rules) {

--- a/js/app/demo/environments.jsx
+++ b/js/app/demo/environments.jsx
@@ -2,9 +2,8 @@
 
 define(['react'], function(React) {
     return function Environments(props) {
-        var envNames = Object.keys(props.env);
         var columnLimit = 3;
-        var rowLimit = Math.ceil(envNames.length / columnLimit);
+        var rowLimit = Math.ceil(props.envNames.length / columnLimit);
         return (
             <div className="row">
                 <div className="container">
@@ -18,7 +17,7 @@ define(['react'], function(React) {
                             return (
                                 <div className="col-md-4" key={columnIndex}>
                                     {
-                                        envNames.slice(columnIndex * rowLimit, (columnIndex + 1) * rowLimit)
+                                        props.envNames.slice(columnIndex * rowLimit, (columnIndex + 1) * rowLimit)
                                             .map(function(envName) {
                                                 return (
                                                     <div className="checkbox" key={envName}>

--- a/js/app/demo/parserOptions.jsx
+++ b/js/app/demo/parserOptions.jsx
@@ -50,11 +50,13 @@ define(['react'], function(React) {
                                                 id={ecmaFeature}
                                                 onChange={
                                                     function(event) {
-                                                        var updatedFeature = {};
-                                                        updatedFeature[ecmaFeature] = event.target.checked;
-                                                        props.onUpdate(Object.assign({}, props.options, {
-                                                            ecmaFeatures: Object.assign({}, props.options.ecmaFeatures, updatedFeature)
-                                                        }))
+                                                        var updatedFeatures = Object.assign({}, props.options.ecmaFeatures);
+                                                        if (event.target.checked) {
+                                                            updatedFeatures[ecmaFeature] = true;
+                                                        } else {
+                                                            delete updatedFeatures[ecmaFeature];
+                                                        }
+                                                        props.onUpdate(Object.assign({}, props.options, { ecmaFeatures: updatedFeatures }))
                                                     }
                                                 }
                                             />

--- a/js/app/demo/rulesConfig.jsx
+++ b/js/app/demo/rulesConfig.jsx
@@ -24,15 +24,13 @@ define(['react'], function(React) {
 
     return function RulesConfig(props) {
         function shouldBeChecked(rule) {
-            var ruleValue = props.config[rule];
-            return typeof ruleValue === 'string' ? ruleValue !== 'off' : ruleValue[0] !== 'off';
+            return props.config[rule] && props.config[rule] !== "off" && props.config[rule] !== 0;
         }
         function getRow(i) {
-            var rules = Object.keys(props.config);
-            var limit = Math.ceil(rules.length / 3);
+            var limit = Math.ceil(props.ruleNames.length / 3);
             const start = limit * i;
             return Array(limit).fill('').map(function(item, index) {
-                var rule = rules[start + index];
+                var rule = props.ruleNames[start + index];
                 return rule && <Rule key={rule} rule={rule} docs={props.docs[rule].docs} isChecked={shouldBeChecked(rule)} handleChange={handleChange} />
             });
         }
@@ -46,15 +44,13 @@ define(['react'], function(React) {
             });
         }
         function handleChange(e, key) {
-            var change = {};
-            var value = e.target.checked ? 'error' : 'off';
-            if (typeof props.config[key] === 'string') {
-                change[key] = value;
+            var updatedConfig = Object.assign({}, props.config);
+            if (e.target.checked) {
+                updatedConfig[key] = "error";
             } else {
-                change[key] = props.config[key];
-                change[key][0] = value;
+                delete updatedConfig[key];
             }
-            props.onUpdate(Object.assign({}, props.config, change));
+            props.onUpdate(updatedConfig);
         }
 
         return (


### PR DESCRIPTION
Fixes https://github.com/eslint/eslint.github.io/issues/99

This updates the demo to allow code and config to be specified with a URL. Hopefully, this should make the demo an easy bug-reporting tool -- as an alternative to filling out information on Node versions etc., users could just paste a link to the demo with a particular code and config to demonstrate the bug.

The serialization format is:

`atob(JSON.stringify({ text: "the text", options: { /* the config */ })`

The serialized state is placed in the URL hash whenever the config or text is changed.

This commit also updates the config-building logic to make the serialized configs smaller, to prevent the URLs from getting too long. In particular, rules that were previously configured with `"off"` are now omitted from the config, and envs that were previously `false` are now omitted.

Even with these changes, the URL for the default state is still very long, because every rule from `eslint:recommended` is explicitly enabled in the demo config by default:

<details>
<summary>URL for default text/config</summary>

```
https://eslint.org/demo/#eyJ0ZXh0IjoidmFyIGZvbyA9IGJhcjsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjUsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnsianN4IjpmYWxzZSwiZ2xvYmFsUmV0dXJuIjpmYWxzZSwiaW1wbGllZFN0cmljdCI6ZmFsc2UsImV4cGVyaW1lbnRhbE9iamVjdFJlc3RTcHJlYWQiOmZhbHNlfX0sInJ1bGVzIjp7ImNvbnN0cnVjdG9yLXN1cGVyIjoiZXJyb3IiLCJuby1jYXNlLWRlY2xhcmF0aW9ucyI6ImVycm9yIiwibm8tY2xhc3MtYXNzaWduIjoiZXJyb3IiLCJuby1jb21wYXJlLW5lZy16ZXJvIjoiZXJyb3IiLCJuby1jb25kLWFzc2lnbiI6ImVycm9yIiwibm8tY29uc29sZSI6ImVycm9yIiwibm8tY29uc3QtYXNzaWduIjoiZXJyb3IiLCJuby1jb25zdGFudC1jb25kaXRpb24iOiJlcnJvciIsIm5vLWNvbnRyb2wtcmVnZXgiOiJlcnJvciIsIm5vLWRlYnVnZ2VyIjoiZXJyb3IiLCJuby1kZWxldGUtdmFyIjoiZXJyb3IiLCJuby1kdXBlLWFyZ3MiOiJlcnJvciIsIm5vLWR1cGUtY2xhc3MtbWVtYmVycyI6ImVycm9yIiwibm8tZHVwZS1rZXlzIjoiZXJyb3IiLCJuby1kdXBsaWNhdGUtY2FzZSI6ImVycm9yIiwibm8tZW1wdHktY2hhcmFjdGVyLWNsYXNzIjoiZXJyb3IiLCJuby1lbXB0eS1wYXR0ZXJuIjoiZXJyb3IiLCJuby1lbXB0eSI6ImVycm9yIiwibm8tZXgtYXNzaWduIjoiZXJyb3IiLCJuby1leHRyYS1ib29sZWFuLWNhc3QiOiJlcnJvciIsIm5vLWV4dHJhLXNlbWkiOiJlcnJvciIsIm5vLWZhbGx0aHJvdWdoIjoiZXJyb3IiLCJuby1mdW5jLWFzc2lnbiI6ImVycm9yIiwibm8tZ2xvYmFsLWFzc2lnbiI6ImVycm9yIiwibm8taW5uZXItZGVjbGFyYXRpb25zIjoiZXJyb3IiLCJuby1pbnZhbGlkLXJlZ2V4cCI6ImVycm9yIiwibm8taXJyZWd1bGFyLXdoaXRlc3BhY2UiOiJlcnJvciIsIm5vLW1peGVkLXNwYWNlcy1hbmQtdGFicyI6ImVycm9yIiwibm8tbmV3LXN5bWJvbCI6ImVycm9yIiwibm8tb2JqLWNhbGxzIjoiZXJyb3IiLCJuby1vY3RhbCI6ImVycm9yIiwibm8tcmVkZWNsYXJlIjoiZXJyb3IiLCJuby1yZWdleC1zcGFjZXMiOiJlcnJvciIsIm5vLXNlbGYtYXNzaWduIjoiZXJyb3IiLCJuby1zcGFyc2UtYXJyYXlzIjoiZXJyb3IiLCJuby10aGlzLWJlZm9yZS1zdXBlciI6ImVycm9yIiwibm8tdW5kZWYiOiJlcnJvciIsIm5vLXVuZXhwZWN0ZWQtbXVsdGlsaW5lIjoiZXJyb3IiLCJuby11bnJlYWNoYWJsZSI6ImVycm9yIiwibm8tdW5zYWZlLWZpbmFsbHkiOiJlcnJvciIsIm5vLXVuc2FmZS1uZWdhdGlvbiI6ImVycm9yIiwibm8tdW51c2VkLWxhYmVscyI6ImVycm9yIiwibm8tdW51c2VkLXZhcnMiOiJlcnJvciIsIm5vLXVzZWxlc3MtZXNjYXBlIjoiZXJyb3IiLCJyZXF1aXJlLXlpZWxkIjoiZXJyb3IiLCJ1c2UtaXNuYW4iOiJlcnJvciIsInZhbGlkLXR5cGVvZiI6ImVycm9yIn0sImVudiI6e319fQ==
```
</details>

It might be possible to make this shorter in the default case by making the config extend from `eslint:recommended`, and then explicitly disabling rules from `eslint:recommended` in the config if necessary.

Security considerations:

* If it's possible to cause ESLint to execute custom code when linting a given text with a given config, then this change will allow [reflected XSS](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)) on the `eslint.org` origin. An attacker could get a victim to click a link/load an iframe with a URL that puts malicious code in the demo, and some JavaScript would get run in the user's browser. `eslint.org` is a static site, so it would be difficult for an attacker to cause any significant damage, but reflected XSS is still undesirable. This change assumes that it's not possible for this to happen when linting untrusted code.
* An attacker could tamper with the user's cached state in `localStorage` by getting the user to click a link/load an iframe with different code/config. This could be mildly annoying for the user. To avoid this, if code is loaded from the URL hash, the state is not saved to `localStorage` until the user modifies the code or the config.