### PR TITLE
Use 2 instead of "error" internally for demo configs

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -92,7 +92,7 @@ define(['react', 'jsx!editor', 'jsx!messages', 'jsx!fixedCode', 'jsx!configurati
                         var result = {};
                         rules.forEach(function(rule, ruleId) {
                             if (rule.meta.docs.recommended) {
-                                result[ruleId] = "error";
+                                result[ruleId] = 2;
                             }
                         });
                         return result;

--- a/js/app/demo/rulesConfig.jsx
+++ b/js/app/demo/rulesConfig.jsx
@@ -46,7 +46,7 @@ define(['react'], function(React) {
         function handleChange(e, key) {
             var updatedConfig = Object.assign({}, props.config);
             if (e.target.checked) {
-                updatedConfig[key] = "error";
+                updatedConfig[key] = 2;
             } else {
                 delete updatedConfig[key];
             }


### PR DESCRIPTION
This makes the serialized configs smaller, which reduces the URL size.