### PR TITLE
Fix incorrect falsy check for localStorage stored state

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -54,7 +54,7 @@ define(['react', 'jsx!editor', 'jsx!messages', 'jsx!fixedCode', 'jsx!configurati
     return React.createClass({
         displayName: 'App',
         getInitialState: function() {
-            var storedState = JSON.parse(window.localStorage.getItem('linterDemoState') || '{}');
+            var storedState = JSON.parse(window.localStorage.getItem('linterDemoState') || null);
             var urlState = (function() {
                 try {
                     return JSON.parse(window.atob(window.location.hash.replace(/^#/, "")));


### PR DESCRIPTION
Previously, the function to get state from `localStorage` would return an empty object as the default value if there was nothing stored. However, another part of the code was checking whether the value was falsy. This was causing crashes when going to https://eslint.org/demo without any stored state or additional data in the URL.

This commit updates the `localStorage` handler to return `null` as the default value.