### PR TITLE
Fix issue where "fix" state was sometimes unset

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -63,27 +63,29 @@ define(['react', 'jsx!editor', 'jsx!messages', 'jsx!fixedCode', 'jsx!configurati
                 }
             }());
 
-            var initialState = urlState || storedState || {
-                options: {
-                    parserOptions: {
-                        ecmaVersion: 5,
-                        sourceType: 'script',
-                        ecmaFeatures: {}
+            var initialState = Object.assign(
+                { fix: false },
+                urlState || storedState || {
+                    options: {
+                        parserOptions: {
+                            ecmaVersion: 5,
+                            sourceType: 'script',
+                            ecmaFeatures: {}
+                        },
+                        rules: (function() {
+                            var result = {};
+                            rules.forEach(function(rule, ruleId) {
+                                if (rule.meta.docs.recommended) {
+                                    result[ruleId] = 2;
+                                }
+                            });
+                            return result;
+                        }()),
+                        env: {}
                     },
-                    rules: (function() {
-                        var result = {};
-                        rules.forEach(function(rule, ruleId) {
-                            if (rule.meta.docs.recommended) {
-                                result[ruleId] = 2;
-                            }
-                        });
-                        return result;
-                    }()),
-                    env: {}
-                },
-                text: 'var foo = bar;',
-                fix: false,
-            };
+                    text: 'var foo = bar;',
+                }
+            );
 
             this.initialText = initialState.text;
             return initialState;


### PR DESCRIPTION
When loading code from a URL, the the value of `this.state.fix` would end up undefined. This would result in ESLint running in autofix mode, but the "fix" tab wouldn't get displayed, resulting in some missing problems.

[Example](https://eslint.org/demo/#eyJ0ZXh0IjoiZm9vIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo4LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7InNlbWkiOjJ9LCJlbnYiOnt9fX0=)

Note that there are initially no errors, but switching to the "fix" tab and back causes a `semi` error to appear.