### PR TITLE
Add link to download .eslintrc.json file (fixes #110)

### DIFF
--- a/js/app/demo/configuration.jsx
+++ b/js/app/demo/configuration.jsx
@@ -43,6 +43,16 @@ define(["react", "jsx!parserOptions", "jsx!environments", "jsx!rulesConfig"], fu
                                     }
                                 }
                             />
+                            <hr />
+                            <a
+                                download=".eslintrc.json"
+                                href={
+                                    "data:application/json;charset=utf-8," +
+                                    encodeURIComponent(JSON.stringify(props.options, null, 4))
+                                }
+                            >
+                                Download <code className="highlighter-rouge">.eslintrc.json</code> file with this configuration
+                            </a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
This adds a link to download the current config in the demo as a JSON file.

Unfortunately, it seems like browsers don't allow downloads to have a `.` as the first character of the filename by default (see [here](https://stackoverflow.com/questions/38931933/download-dotfile-using-html5-download-preserving-name)). So even though the `download` attribute specifies the filename as `.eslintrc.json`, the file actually gets saved as `eslintrc.json` (no dot). It's possible for the user to manually change the filename if they've configured their browser settings appropriately, but most users probably won't know to do that.