### PR TITLE
Improve multiline-comment-style docs

### DIFF
--- a/docs/rules/multiline-comment-style.md
+++ b/docs/rules/multiline-comment-style.md
@@ -25,21 +25,9 @@ This rule has a string option, which can have one of the following values:
 
 The rule always ignores directive comments such as `/* eslint-disable */`. Additionally, unless the mode is `"starred-block"`, the rule ignores JSDoc comments.
 
-Examples of **incorrect** code for this rule:
+Examples of **incorrect** code for this rule with the default `"starred-block"` option:
 
 ```js
-
-/* eslint multiline-comment-style: ["error", "separate-lines"] */
-
-/* This line
-calls foo() */
-foo();
-
-/*
- * This line
- * calls foo()
- */
-foo();
 
 /* eslint multiline-comment-style: ["error", "starred-block"] */
 
@@ -67,6 +55,25 @@ foo();
  * the star on the following line should have a space before it
 */
 
+```
+
+Examples of **correct** code for this rule with the default `"starred-block"` option:
+
+```js
+/* eslint multiline-comment-style: ["error", "starred-block"] */
+
+/*
+ * this line
+ * calls foo()
+ */
+foo();
+
+// single-line comment
+```
+
+Examples of **incorrect** code for this rule with the `"bare-block"` option:
+
+```js
 /* eslint multiline-comment-style: ["error", "bare-block"] */
 
 // this line
@@ -78,10 +85,37 @@ foo();
  * calls foo()
  */
 foo();
+```
+
+Examples of **correct** code for this rule with the `"bare-block"` option:
+
+```js
+/* eslint multiline-comment-style: ["error", "bare-block"] */
+
+/* this line
+   calls foo() */
+foo();
+```
+
+Examples of **incorrect** code for this rule with the `"separate-lines"` option:
+
+```js
+
+/* eslint multiline-comment-style: ["error", "separate-lines"] */
+
+/* This line
+calls foo() */
+foo();
+
+/*
+ * This line
+ * calls foo()
+ */
+foo();
 
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule with the `"separate-lines"` option:
 
 ```js
 /* eslint multiline-comment-style: ["error", "separate-lines"] */
@@ -90,21 +124,6 @@ Examples of **correct** code for this rule:
 // calls foo()
 foo();
 
-
-/* eslint multiline-comment-style: ["error", "starred-block"] */
-
-/*
- * this line
- * calls foo()
- */
-foo();
-
-
-/* eslint multiline-comment-style: ["error", "bare-block"] */
-
-/* this line
-   calls foo() */
-foo();
 
 ```
 


### PR DESCRIPTION
This applies the changes from https://github.com/eslint/eslint/pull/9440 directly to the site, for the benefit of users who read the docs before the next release.