### PR TITLE
Fix: support Unicode in URL hash

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configuration", "eslint"], function(React, Editor, Messages, FixedCode, Configuration, Linter) {
+define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configuration", "eslint", "unicode"], function(React, Editor, Messages, FixedCode, Configuration, Linter, Unicode) {
     var hasLocalStorage = (function() {
         try {
             window.localStorage.setItem("localStorageTest", "foo");
@@ -58,7 +58,7 @@ define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configurati
             var storedState = JSON.parse(window.localStorage.getItem("linterDemoState") || null);
             var urlState = (function() {
                 try {
-                    return JSON.parse(window.atob(window.location.hash.replace(/^#/, "")));
+                    return JSON.parse(Unicode.decodeFromBase64(window.location.hash.replace(/^#/, "")));
                 } catch (err) {
                     return null;
                 }
@@ -108,7 +108,7 @@ define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configurati
             if (hasLocalStorage) {
                 window.localStorage.setItem("linterDemoState", serializedState);
             }
-            window.location.hash = window.btoa(serializedState);
+            window.location.hash = Unicode.encodeToBase64(serializedState);
         },
         enableFixMode: function() {
             this.setState({ fix: true });

--- a/js/app/demo/unicode.js
+++ b/js/app/demo/unicode.js
@@ -1,0 +1,16 @@
+"use strict";
+
+define([], function() {
+
+    // Provides conversion functions between a unicode string and a base64 string.
+    // See also: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings
+    return {
+        encodeToBase64: function(text) {
+            return window.btoa(unescape(encodeURIComponent(text)));
+        },
+
+        decodeFromBase64: function(base64) {
+            return decodeURIComponent(escape(window.atob(base64)));
+        }
+    };
+});


### PR DESCRIPTION
**What did you do?**

I wrote a code which includes non-ASCII characters, `✓` and `✘`, on [the ESLint demo](https://eslint.org/demo/#). <details>

```js
/*eslint lines-between-class-members: error */

//✘ BAD
class Bad {
    foo() {
    }
    bar() {
    }
}

//✓ GOOD
class Bad {
    foo() {
    }

    bar() {
    }
}
```

> https://qiita.com/mysticatea/items/ae0081b3da453b8a3304

</details><br>

**What did you expect to happen?**

I expected that I can get the URL for the code.

**What actually happened?**

I couldn't get the URL. The demo failed to generate the URL silently and reported an error in devtools.

![image](https://user-images.githubusercontent.com/1937871/31597618-55c49cce-b284-11e7-91f8-9eb3ba2524fd.png)

**What changes did you make? (Give an overview)**

This PR makes the ESLint demo supporting Unicode strings for URL hash. This is very useful in order to write release notes in Japanese or other languages, they can make links to the demo which includes descriptions in their language.

I used the way [MDN has described](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa#Unicode_strings).

I checked compatibility with some existing URL, then I didn't find problems.
I believe no problem.

**Is there anything you'd like reviewers to focus on?**

Please check concerns of compatibility.