### PR TITLE
Ensure demo works when running site locally

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -112,7 +112,7 @@
 
   </script>
   {% if page.demopage %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.15/require.min.js" data-main="{{ site.url }}/js/app/demo/requireConfig" defer></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.15/require.min.js" data-main="/js/app/demo/requireConfig" defer></script>
   {% endif %}
 </body>
 </html>


### PR DESCRIPTION
Currently, some resources are loaded from `https://eslint.org` even when running the site locally. Among other things, this was causing the demo to break because `requirejs` handled file extensions differently.