### PR TITLE
Move integrations link above migration guides in the menu

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -28,13 +28,13 @@
             <li><a href="{{ site.url }}/docs/user-guide/command-line-interface">Command Line Interface</a></li>
             <li><a href="{{ site.url }}/docs/rules/">Rules</a></li>
             <li><a href="{{ site.url }}/docs/user-guide/formatters">Formatters</a></li>
+            <li><a href="{{ site.url }}/docs/user-guide/integrations">Integrations</a></li>
             <li class="divider"></li>
             <li><a href="{{ site.url }}/docs/user-guide/migrating-to-1.0.0">Migrating to v1.0.0</a></li>
             <li><a href="{{ site.url }}/docs/user-guide/migrating-to-2.0.0">Migrating to v2.0.0</a></li>
             <li><a href="{{ site.url }}/docs/user-guide/migrating-to-3.0.0">Migrating to v3.0.0</a></li>
             <li><a href="{{ site.url }}/docs/user-guide/migrating-to-4.0.0">Migrating to v4.0.0</a></li>
             <li><a href="{{ site.url }}/docs/user-guide/migrating-from-jscs">Migrating from JSCS</a></li>
-            <li><a href="{{ site.url }}/docs/user-guide/integrations">Integrations</a></li>
           </ul>
         </li>
         <li class="dropdown">


### PR DESCRIPTION
This makes the organization of the menu consistent so that all the migration guides are together below the divider.