### PR TITLE
Update examples for no-useless-escape

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -50,8 +50,8 @@ Examples of **correct** code for this rule:
 "\371";
 "xs\u2111";
 `\``;
-`\${${foo}\}`;
-`$\{${foo}\}`;
+`\${${foo}}`;
+`$\{${foo}}`;
 /\\/g;
 /\t/g;
 /\w\$\*\^\./;


### PR DESCRIPTION
* https://eslint.org/docs/rules/no-useless-escape

Correct examples for `no-useless-escape` occur the errors.
So I've fixed the examples.

Current(copy and paste from the page)

* https://eslint.org/demo/#eyJ0ZXh0IjoiXCJcXFwiXCI7XG4nXFwnJztcblwiXFx4MTJcIjtcblwiXFx1MDBhOVwiO1xuXCJcXDM3MVwiO1xuXCJ4c1xcdTIxMTFcIjtcbmBcXGBgO1xuYFxcJHske2Zvb31cXH1gO1xuYCRcXHske2Zvb31cXH1gO1xuL1xcXFwvZztcbi9cXHQvZztcbi9cXHdcXCRcXCpcXF5cXC4vOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6eyJuby11c2VsZXNzLWVzY2FwZSI6Mn0sImVudiI6e319fQ==

Fixed version

* https://eslint.org/demo/#eyJ0ZXh0IjoiXCJcXFwiXCI7XG4nXFwnJztcblwiXFx4MTJcIjtcblwiXFx1MDBhOVwiO1xuXCJcXDM3MVwiO1xuXCJ4c1xcdTIxMTFcIjtcbmBcXGBgO1xuYFxcJHske2Zvb319YDtcbmAkXFx7JHtmb299fWA7XG4vXFxcXC9nO1xuL1xcdC9nO1xuL1xcd1xcJFxcKlxcXlxcLi87Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7Im5vLXVzZWxlc3MtZXNjYXBlIjoyfSwiZW52Ijp7fX19

Actually, this is a useless escape

* https://jsfiddle.net/koba04/f1t7qr1n/

Thanks!