### PR TITLE
Clarify default ignoring of node_modules

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -840,15 +840,17 @@ Globs are matched using [node-ignore](https://github.com/kaelzhang/node-ignore),
 
 In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `/node_modules/*` and `/bower_components/*`.
 
-For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules`, `bower_components` and anything in the `build/` directory except `build/index.js`:
+For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules`, `bower_components` in the project root and anything in the `build/` directory except `build/index.js`:
 
 ```text
-# /node_modules/* and /bower_components/* ignored by default
+# /node_modules/* and /bower_components/* in the project root are ignored by default
 
 # Ignore built files except build/index.js
 build/*
 !build/index.js
 ```
+
+**Important**: Note that `node_modules` in for example `packages` directories are *not* ignored by default and need to be added to `.eslintignore` explicitly.
 
 ### Using an Alternate File
 


### PR DESCRIPTION
When using ESLint from the root of a mono repo `node_modules` needs to be explicitly added to `.eslintignore` for ESLint to ignore for example `packages/*/node_modules`. Clarified this in the configuring documentation.