### PR TITLE
Fix: show popover for rulesConfig (fixes #437)

### DIFF
--- a/js/app/demo/configuration.jsx
+++ b/js/app/demo/configuration.jsx
@@ -1,5 +1,7 @@
 "use strict";
 
+/* global Popover */
+
 define(["react", "jsx!parserOptions", "jsx!environments", "jsx!rulesConfig"], function(React, ParserOptions, Environments, RulesConfig) {
     return React.createClass({
         displayName: "Configuration",
@@ -10,7 +12,7 @@ define(["react", "jsx!parserOptions", "jsx!environments", "jsx!rulesConfig"], fu
             var popoverElements = document.querySelectorAll("[data-toggle=\"popover\"]");
 
             for (var i = 0; i < popoverElements.length; ++i) {
-                // eslint-disable-next-line no-new, no-undef
+                // eslint-disable-next-line no-new
                 new Popover(popoverElements[i]);
             }
         },

--- a/js/app/demo/configuration.jsx
+++ b/js/app/demo/configuration.jsx
@@ -6,10 +6,27 @@ define(["react", "jsx!parserOptions", "jsx!environments", "jsx!rulesConfig"], fu
         getInitialState: function() {
             return { showingConfig: false };
         },
+        initPopovers: function() {
+            var popoverElements = document.querySelectorAll("[data-toggle=\"popover\"]");
+
+            for (var i = 0; i < popoverElements.length; ++i) {
+                // eslint-disable-next-line no-new, no-undef
+                new Popover(popoverElements[i]);
+            }
+        },
         toggleShowingConfig: function() {
-            this.setState(function(state) {
-                return { showingConfig: !state.showingConfig };
-            });
+            var obj = this;
+
+            this.setState(
+                function(state) {
+                    return { showingConfig: !state.showingConfig };
+                },
+                function() {
+                    if (obj.state.showingConfig) {
+                        obj.initPopovers();
+                    }
+                }
+            );
         },
         render: function Configuration() {
             return (

--- a/js/app/demo/rulesConfig.jsx
+++ b/js/app/demo/rulesConfig.jsx
@@ -3,14 +3,15 @@
 define(["react", "jsx!selectAllCheckbox"], function(React, SelectAllCheckbox) {
 
     function Rule(ref) {
+
         function handler(e) {
             ref.handleChange(e, ref.rule);
         }
         function showPopover(e) {
-            $(e.currentTarget).popover("show");
+            e.currentTarget.Popover.show();
         }
         function hidePopover(e) {
-            $(e.currentTarget).popover("hide");
+            e.currentTarget.Popover.hide();
         }
 
         return (


### PR DESCRIPTION
The bootstrap native popover objects were not being initialized. I added the initialization and refactored the show / hide toggle to match the bootstrap native [guide](https://thednp.github.io/bootstrap.native/)