### PR TITLE
Add highlights for v5.0.0-alpha.2

### DIFF
--- a/_posts/2018-04-27-eslint-v5.0.0-alpha.2-released.md
+++ b/_posts/2018-04-27-eslint-v5.0.0-alpha.2-released.md
@@ -7,10 +7,29 @@ tags:
 ---
 # ESLint v5.0.0-alpha.2 released
 
-We just pushed ESLint v5.0.0-alpha.2, which is a major release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release. This release also has some breaking changes, so please read the following closely. 
+We just pushed ESLint v5.0.0-alpha.2, which is a major release upgrade of ESLint. This release adds some new features and fixes several bugs found in the previous release. This release also has some breaking changes, so please read the following closely.
 
+## Highlights
 
+This is a summary of the major changes you need to know about for this version of ESLint.
 
+### Installing
+
+Since this is a pre-release version, you will not automatically be upgraded by npm. You must specify the `next` tag when installing:
+
+```
+npm i eslint@next --save-dev
+```
+
+You can also specify the version directly:
+
+```
+npm i eslint@5.0.0-alpha.2 --save-dev
+```
+
+### Migration Guide
+
+As there are a lot of changes, we've created a [migration guide](/docs/5.0.0/user-guide/migrating-to-5.0.0) describing the changes in great detail along with the steps you should take to address them. We expect that most users should be able to upgrade without any build changes, but the migration guide should be a useful resource if you encounter problems.
 
 ## Breaking Changes
 


### PR DESCRIPTION
This is basically the same as the highlights for last alpha release except that the version is changed. (Most of the actual discussion of highlights is in the migration guide.)