### PR TITLE
Chore: fix linting errors in image-lazy-loader

### DIFF
--- a/js/app/image-lazy-loader.js
+++ b/js/app/image-lazy-loader.js
@@ -1,4 +1,6 @@
-var ImageObserver = (function() {
+"use strict";
+
+window.ImageObserver = (function() {
     var observer;
 
     function createObserver() {
@@ -14,16 +16,11 @@ var ImageObserver = (function() {
           "intersectionRatio" in window.IntersectionObserverEntry.prototype &&
           !("isIntersecting" in IntersectionObserverEntry.prototype)) {
             Object.defineProperty(window.IntersectionObserverEntry.prototype, "isIntersecting", {
-                get: function () {
+                get: function() {
                     return this.intersectionRatio > 0;
                 }
             });
         }
-
-        observer = new IntersectionObserver(onChange, {
-            rootMargin: "250px 0px",
-            threshold: 0.01
-        });
 
         function onChange(changes) {
             changes.forEach(function(change) {
@@ -34,6 +31,11 @@ var ImageObserver = (function() {
                 }
             });
         }
+
+        observer = new IntersectionObserver(onChange, {
+            rootMargin: "250px 0px",
+            threshold: 0.01
+        });
     }
 
     function observe() {
@@ -52,4 +54,4 @@ var ImageObserver = (function() {
         createObserver: createObserver,
         observe: observe
     };
-})();
+}());


### PR DESCRIPTION
This fixes some linting errors in `image-lazy-loader`. These made it to master because we don't have a CI build that does linting yet on this repo (see https://github.com/eslint/eslint.github.io/issues/402).