### PR TITLE
Fix: avoid changing URL fragment when switching demo tabs (fixes #469)

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -110,10 +110,12 @@ define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configurati
             }
             window.location.hash = Unicode.encodeToBase64(serializedState);
         },
-        enableFixMode: function() {
+        enableFixMode: function(event) {
+            event.preventDefault();
             this.setState({ fix: true });
         },
-        disableFixMode: function() {
+        disableFixMode: function(event) {
+            event.preventDefault();
             this.setState({ fix: false });
         },
         render: function App() {


### PR DESCRIPTION
See https://github.com/eslint/eslint.github.io/issues/469 for details on the bug.