### PR TITLE
Chore: Run lint task in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 cache: bundler
-branches:
-  only:
-    - master
-script: 
-  - bundle exec jekyll algolia
+before_script:
+  - nvm install --lts
+script:
+  - npm run lint
+after_success:
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then bundle exec jekyll algolia; fi
 rvm:
  - 2.5


### PR DESCRIPTION
This PR simply uses `nvm install` and then `npm run lint` to run the lint tasks. It also moves the algolia to an after_success step.

This is probably not the right approach. A better approach would be to see if we can switch the Travis build language to NodeJS and remove the algolia line entirely since we are now on DocSearch. This is just a POC (to try to see if it might be a viable temporary solution, should the DocSearch questions remain open for a while).