### PR TITLE
Fix: Add missing rules

### DIFF
--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -1,0 +1,65 @@
+---
+title: max-classes-per-file - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/max-classes-per-file.md
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# enforce a maximum number of classes per file (max-classes-per-file)
+
+Files containing multiple classes can often result in a less navigable
+and poorly structured codebase. Best practice is to keep each file
+limited to a single responsibility.
+
+## Rule Details
+
+This rule enforces that each file may contain only a particular number
+of classes and no more.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint max-classes-per-file: "error"*/
+
+class Foo {}
+class Bar {}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint max-classes-per-file: "error"*/
+
+class Foo {}
+```
+
+## Options
+
+This rule has a numeric option (defaulted to 1) to specify the
+maximum number of classes.
+
+For example:
+
+```json
+{
+    "max-classes-per-file": ["error", 1]
+}
+```
+
+Examples of **correct** code for this rule with the numeric option set to `2`:
+
+```js
+/* eslint max-classes-per-file: ["error", 2] */
+
+class Foo {}
+class Bar {}
+```
+
+## Version
+
+This rule was introduced in ESLint 5.0.0-alpha.3.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/max-classes-per-file.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/max-classes-per-file.md)

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -1,0 +1,65 @@
+---
+title: prefer-object-spread - Rules
+layout: doc
+edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/prefer-object-spread.md
+---
+<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->
+
+# Prefer use of an object spread over `Object.assign` (prefer-object-spread)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.
+
+When Object.assign is called using an object literal as the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+Object.assign({}, foo)
+
+Object.assign({}, {foo: 'bar'})
+
+Object.assign({ foo: 'bar'}, baz)
+
+Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }))
+
+Object.assign({}, { foo, bar, baz })
+
+Object.assign({}, { ...baz })
+
+// Object.assign with a single argument that is an object literal
+Object.assign({});
+
+Object.assign({ foo: bar });
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+Object.assign(...foo);
+
+// Any Object.assign call without an object literal as the first argument
+Object.assign(foo, { bar: baz });
+
+Object.assign(foo, Object.assign(bar));
+
+Object.assign(foo, { bar, baz })
+
+Object.assign(foo, { ...baz });
+```
+
+## When Not To Use It
+
+When you don't care about syntactic sugar added by the object spread property.
+
+## Version
+
+This rule was introduced in ESLint 5.0.0-alpha.3.
+
+## Resources
+
+* [Rule source](https://github.com/eslint/eslint/tree/master/lib/rules/prefer-object-spread.js)
+* [Documentation source](https://github.com/eslint/eslint/tree/master/docs/rules/prefer-object-spread.md)


### PR DESCRIPTION
This will fix 404 responses for links that point to `max-classes-per-file` and `prefer-object-spread` rules.

Root cause is eslint/eslint-release#22. Hopefully we can fix that before next release!