### PR TITLE
Fix: hidden icons on smartphone device

### DIFF
--- a/styles/less/overrides.less
+++ b/styles/less/overrides.less
@@ -69,6 +69,11 @@ p {
     left: -1.5em; /* negative padding-left of ul */
     font-family: "Glyphicons Halflings";
     color: #4d4d4d; /* hsl(0,0%,30%) is 10% lighter gray than text */
+
+    @media (max-width: @screen-xs-max) {
+      position: static;
+      margin-right: 0.5em;
+    }
   }
 
   &.removed ~ p.fixable:before {


### PR DESCRIPTION
This fixes the problem that icons at the beginning of paragraphs are hidden on smartphone device.

`@media (max-width: @screen-xs-max)` means small devices (`< 768px`) in Bootstrap 3.
Please see <https://getbootstrap.com/docs/3.3/css/#grid-media-queries>.

### Before

![image](https://user-images.githubusercontent.com/473530/41154517-5866f9e2-6b55-11e8-9037-0500cbf94632.png)

### After

![image](https://user-images.githubusercontent.com/473530/41154537-63877d06-6b55-11e8-907b-7bae88ba69f3.png)


