### PR TITLE
Format "consistent" consistently

### DIFF
--- a/_posts/2018-06-22-eslint-v5.0.0-released.md
+++ b/_posts/2018-06-22-eslint-v5.0.0-released.md
@@ -18,7 +18,7 @@ We just pushed ESLint v5.0.0, which is a major release upgrade of ESLint. This r
     * [`max-lines-per-function`](/docs/rules/max-lines-per-function)
 * The [`CLIEngine.executeOnFiles`](/docs/developer-guide/nodejs-api#cliengineexecuteonfiles) API now has a `globInputPaths` option.
 * The [`one-var`](/docs/rules/one-var) rule is now autofixable.
-* The [`array-element-newline`](/docs/rules/array-element-newline) rule now has a `"consistent"` option.
+* The [`array-element-newline`](/docs/rules/array-element-newline) rule now has a `consistent` option.
 * The [`camelcase`](/docs/rules/camelcase) rule now has an `ignoreDestructuring` option.
 * The [`valid-jsdoc`](/docs/rules/valid-jsdoc) rule now has a `requireParamType` option.
 * The [`func-name-matching`](/docs/rules/func-name-matching) rule now has a `considerPropertyDescriptor` option.


### PR DESCRIPTION
This updates the formatting of the word "consistent" to be consistent with the formatting of the other option names in the blogpost.