### PR TITLE
Update: remove experimentalObjectRestSpread option from demo

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -89,6 +89,18 @@ define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configurati
                 }
             );
 
+            if (
+                initialState &&
+                initialState.options &&
+                initialState.options.parserOptions &&
+                initialState.options.parserOptions.ecmaFeatures &&
+                initialState.options.parserOptions.ecmaFeatures.experimentalObjectRestSpread
+            ) {
+
+                // Delete the `experimentalObjectRestSpread` option from old states created when the demo supported the option.
+                delete initialState.options.parserOptions.ecmaFeatures.experimentalObjectRestSpread;
+            }
+
             this.initialText = initialState.text;
             return initialState;
         },

--- a/js/app/demo/parserOptions.jsx
+++ b/js/app/demo/parserOptions.jsx
@@ -40,7 +40,7 @@ define(["react"], function(React) {
                     <h3>ECMA Features</h3>
                     <div className="ecmaFeatures list">
                         {
-                            ["jsx", "globalReturn", "impliedStrict", "experimentalObjectRestSpread"].map(function(ecmaFeature) {
+                            ["jsx", "globalReturn", "impliedStrict"].map(function(ecmaFeature) {
                                 return (
                                     <div className="checkbox" key={ecmaFeature}>
                                         <label htmlFor={ecmaFeature}>


### PR DESCRIPTION
The `experimentalObjectRestSpread` option is deprecated, so it's probably not necessary to have it in the demo.