### PR TITLE
Update 2018-10-12-eslint-v5.7.0-released.md

### DIFF
--- a/_posts/2018-10-12-eslint-v5.7.0-released.md
+++ b/_posts/2018-10-12-eslint-v5.7.0-released.md
@@ -18,7 +18,7 @@ Three rules gained new options in this release:
 
 - [`padding-line-between-statements`](/docs/rules/padding-line-between-statements) has a new `iife` node type to specifically target immediately-invoked function expression invocations as distinct statements.
 - [`no-tabs`](/docs/rules/no-tabs) has a new `allowIndentationTabs` option to permit tabs only for indentation and nowhere else.
-- [`camelcase`](/docs/rules/camelcase) has a new `ignoreList` option that can be configured to individually allow certain non-camelcase identifiers like React's `UNSAFE_componentWillMount`.
+- [`camelcase`](/docs/rules/camelcase) has a new `allow` option that can be configured to individually allow certain non-camelcase identifiers like React's `UNSAFE_componentWillMount`.
 
 
 


### PR DESCRIPTION
This PR fixes a wrong option name in highlights.