### PR TITLE
New: Add /team page

### DIFF
--- a/_data/team.json
+++ b/_data/team.json
@@ -1,0 +1,158 @@
+{
+    "tsc": [
+        {
+            "username": "nzakas",
+            "name": "Nicholas C. Zakas",
+            "website": "https://humanwhocodes.com",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/38546?v=4"
+        },
+        {
+            "username": "platinumazure",
+            "name": "Kevin Partington",
+            "website": "",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/284282?v=4"
+        },
+        {
+            "username": "ilyavolodin",
+            "name": "Ilya Volodin",
+            "website": "",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/1380062?v=4"
+        },
+        {
+            "username": "btmills",
+            "name": "Brandon Mills",
+            "website": "https://bmills.net",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/1709537?v=4"
+        },
+        {
+            "username": "mysticatea",
+            "name": "Toru Nagashima",
+            "website": "https://plus.google.com/u/0/+ToruNagashimax/",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/1937871?v=4"
+        },
+        {
+            "username": "gyandeeps",
+            "name": "Gyandeep Singh",
+            "website": "https://gyandeeps.com",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/5554486?v=4"
+        },
+        {
+            "username": "kaicataldo",
+            "name": "Kai Cataldo",
+            "website": "https://kaicataldo.com",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/7041728?v=4"
+        },
+        {
+            "username": "not-an-aardvark",
+            "name": "Teddy Katz",
+            "website": "",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/11638619?v=4"
+        }
+    ],
+    "alumni": [
+        {
+            "username": "alberto",
+            "name": "alberto",
+            "website": "http://www.sharpbites.com",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/72561?v=4"
+        },
+        {
+            "username": "BYK",
+            "name": "Burak Yiğit Kaya",
+            "website": "http://byk.im",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/126780?v=4"
+        },
+        {
+            "username": "lo1tuma",
+            "name": "Mathias Schreck",
+            "website": "",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/169170?v=4"
+        },
+        {
+            "username": "michaelficarra",
+            "name": "Michael Ficarra",
+            "website": "https://twitter.com/jspedant",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/218840?v=4"
+        },
+        {
+            "username": "xjamundx",
+            "name": "Jamund Ferguson",
+            "website": "http://www.jamund.com",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/246143?v=4"
+        },
+        {
+            "username": "mikesherov",
+            "name": "Mike Sherov",
+            "website": "",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/364532?v=4"
+        },
+        {
+            "username": "hzoo",
+            "name": "Henry Zhu",
+            "website": "https://www.henryzoo.com",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/588473?v=4"
+        },
+        {
+            "username": "vitorbal",
+            "name": "Vitor Balocco",
+            "website": "https://twitter.com/vitorbal",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/626038?v=4"
+        },
+        {
+            "username": "zxqfox",
+            "name": "Alexej Yaroshevich",
+            "website": "http://about.me/yaroshevich",
+            "avatar_url": "https://avatars3.githubusercontent.com/u/677518?v=4"
+        },
+        {
+            "username": "JamesHenry",
+            "name": "James Henry",
+            "website": "https://jameshenry.blog",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/900523?v=4"
+        },
+        {
+            "username": "markelog",
+            "name": "Oleg Gaidarenko",
+            "website": "https://twitter.com/arkel",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/945528?v=4"
+        },
+        {
+            "username": "soda0289",
+            "name": "Reyad Attiyat",
+            "website": "",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/2373964?v=4"
+        },
+        {
+            "username": "VictorHom",
+            "name": "Victor Hom",
+            "website": "https://twitter.com/victorhomburger",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/3211873?v=4"
+        },
+        {
+            "username": "IanVS",
+            "name": "Ian VanSchooten",
+            "website": "http://devnull.guru",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/4616705?v=4"
+        },
+        {
+            "username": "pedrottimark",
+            "name": "Mark Pedrotti",
+            "website": "http://twitter.com/ittordepam",
+            "avatar_url": "https://avatars1.githubusercontent.com/u/11862657?v=4"
+        }
+    ],
+    "committers": [
+        {
+            "username": "Aladdin-ADD",
+            "name": "薛定谔的猫",
+            "website": "",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/13050025?v=4"
+        },
+        {
+            "username": "eslintbot",
+            "name": "ESLint Bot",
+            "website": "https://eslint.org",
+            "avatar_url": "https://avatars0.githubusercontent.com/u/13383618?v=4"
+        }
+    ]
+}

--- a/_data/team.json
+++ b/_data/team.json
@@ -39,7 +39,7 @@
         {
             "username": "kaicataldo",
             "name": "Kai Cataldo",
-            "website": "https://kaicataldo.com",
+            "website": "",
             "avatar_url": "https://avatars2.githubusercontent.com/u/7041728?v=4"
         },
         {
@@ -147,12 +147,6 @@
             "name": "薛定谔的猫",
             "website": "",
             "avatar_url": "https://avatars2.githubusercontent.com/u/13050025?v=4"
-        },
-        {
-            "username": "eslintbot",
-            "name": "ESLint Bot",
-            "website": "https://eslint.org",
-            "avatar_url": "https://avatars0.githubusercontent.com/u/13383618?v=4"
         }
     ]
 }

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -63,7 +63,15 @@
             <li><a href="{{ site.url }}/parser/">Espree Demo</a></li>
           </ul>
         </li>
-        <li><a href="{{ site.url }}/docs/about/">About</a></li>
+        <!-- <li><a href="{{ site.url }}/docs/about/">About</a></li> -->
+        <li class="dropdown">
+          <a href="{{ site.url }}/docs/about/" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">About<span
+              class="caret"></span></a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="{{ site.url }}/docs/about/">About ESLint</a></li>
+            <li><a href="{{ site.url }}/team/">About the Team</a></li>
+          </ul>
+        </li>
       </ul>
 
       <label for="eslint-toggle-search" class="navbar-toggle eslint-toggle-search-open">

--- a/team/index.md
+++ b/team/index.md
@@ -1,0 +1,65 @@
+---
+title: Team
+layout: doc
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/team/index.md
+---
+
+# Team
+
+These are the people who build and maintain ESLint.
+
+## Technical Steering Committee
+
+The people who manage releases, review feature requests, and meet regularly to ensure ESLint is properly maintained.
+
+<div class="container-fluid">
+    <div class="row">
+
+{% assign tsc = site.data.team.tsc %}
+{% for person in tsc %}
+    <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
+    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
+    </div>
+{% endfor %}
+
+    </div>
+</div>
+
+
+## Committers
+
+The people who review and fix bugs and help triage issues.
+
+<div class="container-fluid">
+    <div class="row">
+
+{% assign committers = site.data.team.committers %}
+{% for person in committers %}
+    <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
+    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
+    </div>
+{% endfor %}
+
+    </div>
+</div>
+
+
+## Alumni
+
+Former TSC members and committers who previously helped maintain ESLint.
+
+<div class="container-fluid">
+    <div class="row">
+
+{% assign alumni = site.data.team.alumni %}
+{% for person in alumni %}
+    <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
+    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
+    </div>
+{% endfor %}
+
+    </div>
+</div>


### PR DESCRIPTION
I've added a `/team` page an updated the "About" link in the heading to be a dropdown that has "About ESLint" and "About the Team". The grid is responsive, going down to just two columns on mobile and up to four columns on larger screens.

![screen shot 2018-11-30 at 11 06 33](https://user-images.githubusercontent.com/38546/49309453-251e2280-f490-11e8-8037-11f08902ece0.png)
