### PR TITLE
Add deprecation notices to JSDoc rules

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -8,6 +8,8 @@ rule_type: suggestion
 
 # require JSDoc comments (require-jsdoc)
 
+This rule was **deprecated** in ESLint v5.10.0.
+
 [JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
 
 ```js

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -10,6 +10,8 @@ rule_type: suggestion
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
+This rule was **deprecated** in ESLint v5.10.0.
+
 [JSDoc](http://usejsdoc.org) generates application programming interface (API) documentation from specially-formatted comments in JavaScript code. For example, this is a JSDoc comment for a function:
 
 ```js


### PR DESCRIPTION
This applies the changes from https://github.com/eslint/eslint/commit/617a2874ed085bca36ca289aac55e3b7f7ce937e to the live site.