### PR TITLE
Update: Add Reviewers to team page (when present)

### DIFF
--- a/_data/team.json
+++ b/_data/team.json
@@ -147,6 +147,7 @@
             "avatar_url": "https://avatars1.githubusercontent.com/u/11862657?v=4"
         }
     ],
+    "reviewers": [],
     "committers": [
         {
             "username": "aladdin-add",

--- a/_tools/fetch-team-data.js
+++ b/_tools/fetch-team-data.js
@@ -34,11 +34,13 @@ if (!ESLINT_GITHUB_TOKEN) {
 const ALUMNI_TEAM_ID = "3005888";
 const TSC_TEAM_ID = "2060414";
 const COMMITTERS_TEAM_ID = "1054435";
+const REVIEWERS_TEAM_ID = "3162426";
 
 // lookup table mapping Github team IDs to JSON keys
 const teamIds = {
     [TSC_TEAM_ID]: "tsc",
     [COMMITTERS_TEAM_ID]: "committers",
+    [REVIEWERS_TEAM_ID]: "reviewers",
     [ALUMNI_TEAM_ID]: "alumni"
 };
 
@@ -46,6 +48,7 @@ const teamIds = {
 const team = {
     tsc: [],
     alumni: [],
+    reviewers: [],
     committers: []
 };
 
@@ -60,7 +63,7 @@ const team = {
         token: ESLINT_GITHUB_TOKEN
     });
 
-    for (const teamId of [TSC_TEAM_ID, ALUMNI_TEAM_ID, COMMITTERS_TEAM_ID]) {
+    for (const teamId of [TSC_TEAM_ID, ALUMNI_TEAM_ID, COMMITTERS_TEAM_ID, REVIEWERS_TEAM_ID]) {
         const { data: result } = await octokit.teams.listMembers({
             team_id: teamId,
             per_page: 100
@@ -80,8 +83,11 @@ const team = {
 
     }
 
-    // filter out TSC members from committers list
-    team.committers = team.committers.filter(user => !team.tsc.find(tscmember => tscmember.username === user.username));
+    // filter out TSC members and reviewers from committers list
+    team.committers = team.committers.filter(user => {
+        return !team.tsc.find(tscmember => tscmember.username === user.username)
+            && !team.reviewers.find(tscmember => tscmember.username === user.username);
+    });
 
     fs.writeFileSync(filename, JSON.stringify(team, null, "    "), { encoding: "utf8" });
 })();

--- a/team/index.md
+++ b/team/index.md
@@ -18,7 +18,7 @@ The people who manage releases, review feature requests, and meet regularly to e
 {% assign tsc = site.data.team.tsc %}
 {% for person in tsc %}
     <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
-    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    <a href="https://github.com/{{ person.username }}"><img src="https://github.com/{{person.username}}.png?s=150" width="150"></a><br>
     {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
     </div>
 {% endfor %}
@@ -26,7 +26,30 @@ The people who manage releases, review feature requests, and meet regularly to e
     </div>
 </div>
 
+{% assign reviewers = site.data.team.reviewers %}
+{% if reviewers.size > 0 %}
+## Reviewers
 
+The people who review and implement new features.
+
+<div class="container-fluid">
+    <div class="row">
+
+{% for person in reviewers %}
+    <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
+    <a href="https://github.com/{{ person.username }}"><img src="https://github.com/{{person.username}}.png?s=150" width="150"></a><br>
+    {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
+    </div>
+{% endfor %}
+
+    </div>
+</div>
+{% endif %}
+
+
+
+{% assign committers = site.data.team.committers %}
+{% if committers.size > 0 %}
 ## Committers
 
 The people who review and fix bugs and help triage issues.
@@ -34,17 +57,16 @@ The people who review and fix bugs and help triage issues.
 <div class="container-fluid">
     <div class="row">
 
-{% assign committers = site.data.team.committers %}
 {% for person in committers %}
     <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
-    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    <a href="https://github.com/{{ person.username }}"><img src="https://github.com/{{person.username}}.png?s=150" width="150"></a><br>
     {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
     </div>
 {% endfor %}
 
     </div>
 </div>
-
+{% endif %}
 
 ## Alumni
 
@@ -56,7 +78,7 @@ Former TSC members and committers who previously helped maintain ESLint.
 {% assign alumni = site.data.team.alumni %}
 {% for person in alumni %}
     <div class="col-xs-6 col-sm-4 col-md-3 text-center" style="margin-bottom: 2rem">
-    <a href="https://github.com/{{ person.username }}"><img src="{{ person.avatar_url }}" width="150"></a><br>
+    <a href="https://github.com/{{ person.username }}"><img src="https://github.com/{{person.username}}.png?s=150" width="150"></a><br>
     {{ person.name }}<br><a href="https://github.com/{{ person.username }}">@{{ person.username }}</a>
     </div>
 {% endfor %}


### PR DESCRIPTION
This PR updates the team fetch script and team page to include members of the new "ESLint Reviewers" team. (Reviewers are only shown on the team page when there is at least one member.)