### PR TITLE
Chore: Sort sponsor data by monthly donation

### DIFF
--- a/_data/sponsors.json
+++ b/_data/sponsors.json
@@ -4,18 +4,21 @@
             "name": "Airbnb",
             "url": "https://www.airbnb.com/",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F098e3bd0-4d57-11e8-9324-0f6cc1f92bf1.png&height=96",
+            "monthlyDonation": 100500,
             "totalDonations": 201000
         },
         {
             "name": "Facebook Open Source",
             "url": "https://code.facebook.com/projects/",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fres.cloudinary.com%2Fopencollective%2Fimage%2Fupload%2Fv1508519428%2FS9gk78AS_400x400_fulq2l.jpg&height=96",
+            "monthlyDonation": 100000,
             "totalDonations": 200000
         },
         {
             "name": "Badoo",
             "url": "https://badoo.com/team?utm_source=eslint",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fbbdb9cc0-3b5d-11e9-9537-ad85092287b8.png&height=96",
+            "monthlyDonation": 100000,
             "totalDonations": 200000
         }
     ],
@@ -24,6 +27,7 @@
             "name": "AMP Project",
             "url": "https://www.ampproject.org/",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F68ed8b70-ebf2-11e6-9958-cb7e79408c56.png&height=96",
+            "monthlyDonation": 50000,
             "totalDonations": 100000
         }
     ],
@@ -32,12 +36,14 @@
             "name": "Faithlife",
             "url": "http://faithlife.com/ref/about",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Ffaithlife.com&height=96",
+            "monthlyDonation": 20000,
             "totalDonations": 40000
         },
         {
             "name": "JSHeroes ",
             "url": "https://jsheroes.io/",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fjsheroes.io&height=96",
+            "monthlyDonation": 20000,
             "totalDonations": 20000
         }
     ],
@@ -46,259 +52,302 @@
             "name": "Addy Osmani",
             "url": "http://www.addyosmani.com",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fe39ad01c67b948f1b9a139a219f2e3d6_a0854b90-b5bf-11e6-9f3b-115a2450f71e.jpeg&height=96",
+            "monthlyDonation": 50000,
             "totalDonations": 50000
-        },
-        {
-            "name": "Frontend Masters",
-            "url": "https://FrontendMasters.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F5e18b6b0-83b4-11e8-97c9-03259cc8bf2b.png&height=96",
-            "totalDonations": 20000
         },
         {
             "name": "Stanislav Cherenkov",
             "url": null,
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2F6cb417c6561ad25d227fbde0e312c678%3Fdefault%3D404&height=96",
+            "monthlyDonation": 7500,
             "totalDonations": 7500
-        },
-        {
-            "name": "Triplebyte",
-            "url": "https://triplebyte.com/os/opencollective",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F02f87560-b2f1-11e8-85a0-75f200a0e2db.png&height=96",
-            "totalDonations": 6000
-        },
-        {
-            "name": "Neovation Learning Solutions",
-            "url": "https://www.neovation.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fneovation.com&height=96",
-            "totalDonations": 5000
         },
         {
             "name": "daniel meyer",
             "url": null,
             "image": null,
+            "monthlyDonation": 5000,
             "totalDonations": 5000
         },
         {
             "name": "Scott Koenig",
             "url": null,
             "image": null,
+            "monthlyDonation": 5000,
             "totalDonations": 5000
         },
         {
             "name": "Budnix",
             "url": "https://budnix.pl",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2F38ff86349fa2ee1ea1e40d91180a6a57%3Fdefault%3D404&height=96",
+            "monthlyDonation": 5000,
             "totalDonations": 5000
         },
         {
-            "name": "Summit",
-            "url": "https://www.summit.co.uk/",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff53056a0-4a6c-11e9-a73d-1bd1a67bbfe7.png&height=96",
-            "totalDonations": 2000
+            "name": "Neovation Learning Solutions",
+            "url": "https://www.neovation.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fneovation.com&height=96",
+            "monthlyDonation": 2500,
+            "totalDonations": 5000
         },
         {
-            "name": "Benjamin Piouffle",
-            "url": "https://benjamin.piouffle.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F7d515580-cde4-11e8-b995-51bda63ba608.png&height=96",
-            "totalDonations": 1600
-        },
-        {
-            "name": "Open Collective Inc.",
-            "url": "https://opencollective.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F8aa714c0-79fa-11e7-9a37-35a8ed456d67.png&height=96",
-            "totalDonations": 1600
-        },
-        {
-            "name": "Matan Kushner",
-            "url": "http://matchai.me",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F051690c0-24bb-11e9-b372-6b1a73f011d0.png&height=96",
-            "totalDonations": 1500
-        },
-        {
-            "name": "Sergey Bondar",
-            "url": null,
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Ffa901150af7d0bb0e3bbd4acd61f8e49%3Fdefault%3D404&height=96",
-            "totalDonations": 1200
-        },
-        {
-            "name": "Jordan Harband",
-            "url": "https://twitter.com/LJHarb",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2Fa44cdffa-865c-4edd-9a89-c3717b27674e&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Joseph Percy",
+            "name": "Brie Bunge",
             "url": null,
             "image": null,
-            "totalDonations": 1000
-        },
-        {
-            "name": "Alexey Raspopov",
-            "url": "https://alexeyraspopov.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F9332be90-5abb-11e7-9ef0-6343e38e2883.png&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "",
-            "url": null,
-            "image": null,
-            "totalDonations": 1000
-        },
-        {
-            "name": "Nubz Ltd",
-            "url": "http://nubz.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fnubz.com&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Dale Price",
-            "url": "https://twitter.com/eatyrghost",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fae8864231858f9762c3f5c12f83c42f9%3Fdefault%3D404&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Kevin Rambaud",
-            "url": "http://kevinrambaud.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fd02cf77b4463fa17ce5c4624b3d970bd%3Fdefault%3D404&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "qnyp",
-            "url": "https://qnyp.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fqnyp.com&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Pawel Grzybek",
-            "url": "https://pawelgrzybek.com/",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fc8bd1650-2f5d-11e9-9004-2b850be986d3.jpg&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Kevin Lamping",
-            "url": "http://klamp.in",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fd80b4ca0-30af-11e9-83fe-6d2c2c189dcd.jpg&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Thomas Hermann",
-            "url": null,
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2Fa3b05fb8-7b12-4062-9d6f-05e3905bc9c0&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Jarrod Davis",
-            "url": "https://jarrodldavis.com/",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F9c483ae0-33b4-11e9-9a9b-9398d916264d.JPG&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Gavin Mogan",
-            "url": "https://www.gavinmogan.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2FuQiEdvYx_normaljpg_6e91d460-17c0-11e7-a2ff-df948e4c489f.jpeg&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Chih-Hsuan Fan",
-            "url": "http://pymaster.logdown.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2F23f55d49-adcc-45a8-b11e-653870a3182e&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Mariusz Nowak",
-            "url": "https://medikoo.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ffb5be610-3451-11e9-9a9b-9398d916264d.jpg&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Simon Korzun",
-            "url": "http://korzun.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fa5bb532babae931bc81f78202d46ac9f%3Fdefault%3D404&height=96",
-            "totalDonations": 1000
-        },
-        {
-            "name": "Michael Neth",
-            "url": null,
-            "image": null,
-            "totalDonations": 1000
-        },
-        {
-            "name": "Dan Foley",
-            "url": "http://cantremember.com",
-            "image": null,
-            "totalDonations": 1000
-        },
-        {
-            "name": "Maisonette Inc",
-            "url": "https://www.maisonette.com",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fmaisonette.com&height=96",
+            "monthlyDonation": 1000,
             "totalDonations": 1000
         },
         {
             "name": "David Johnston",
             "url": "https://blacksheepcode.com",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fb42892d0-b881-11e8-b4ab-519dd68ec9a0.jpg&height=96",
+            "monthlyDonation": 1000,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Michael Neth",
+            "url": null,
+            "image": null,
+            "monthlyDonation": 1000,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Summit",
+            "url": "https://www.summit.co.uk/",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff53056a0-4a6c-11e9-a73d-1bd1a67bbfe7.png&height=96",
+            "monthlyDonation": 1000,
+            "totalDonations": 2000
+        },
+        {
+            "name": "Matan Kushner",
+            "url": "http://matchai.me",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F051690c0-24bb-11e9-b372-6b1a73f011d0.png&height=96",
+            "monthlyDonation": 750,
+            "totalDonations": 1500
+        },
+        {
+            "name": "Sergey Bondar",
+            "url": null,
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Ffa901150af7d0bb0e3bbd4acd61f8e49%3Fdefault%3D404&height=96",
+            "monthlyDonation": 600,
+            "totalDonations": 1200
+        },
+        {
+            "name": "Benjamin Piouffle",
+            "url": "https://benjamin.piouffle.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F7d515580-cde4-11e8-b995-51bda63ba608.png&height=96",
+            "monthlyDonation": 533,
+            "totalDonations": 1600
+        },
+        {
+            "name": "Jordan Harband",
+            "url": "https://twitter.com/LJHarb",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2Fa44cdffa-865c-4edd-9a89-c3717b27674e&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Joseph Percy",
+            "url": null,
+            "image": null,
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Alexey Raspopov",
+            "url": "https://alexeyraspopov.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F9332be90-5abb-11e7-9ef0-6343e38e2883.png&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "",
+            "url": null,
+            "image": null,
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Nubz Ltd",
+            "url": "http://nubz.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fnubz.com&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Dale Price",
+            "url": "https://twitter.com/eatyrghost",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fae8864231858f9762c3f5c12f83c42f9%3Fdefault%3D404&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Kevin Rambaud",
+            "url": "http://kevinrambaud.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fd02cf77b4463fa17ce5c4624b3d970bd%3Fdefault%3D404&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "qnyp",
+            "url": "https://qnyp.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fqnyp.com&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "AJ Klein",
+            "url": "https://twitter.com/jumbleofideas",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F6c5aac30-3b68-11e9-9537-ad85092287b8.jpg&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 500
+        },
+        {
+            "name": "Kevin Lamping",
+            "url": "http://klamp.in",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fd80b4ca0-30af-11e9-83fe-6d2c2c189dcd.jpg&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Thomas Hermann",
+            "url": null,
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2Fa3b05fb8-7b12-4062-9d6f-05e3905bc9c0&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Jarrod Davis",
+            "url": "https://jarrodldavis.com/",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F9c483ae0-33b4-11e9-9a9b-9398d916264d.JPG&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Gavin Mogan",
+            "url": "https://www.gavinmogan.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2FuQiEdvYx_normaljpg_6e91d460-17c0-11e7-a2ff-df948e4c489f.jpeg&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Chih-Hsuan Fan",
+            "url": "http://pymaster.logdown.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2F23f55d49-adcc-45a8-b11e-653870a3182e&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Mariusz Nowak",
+            "url": "https://medikoo.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ffb5be610-3451-11e9-9a9b-9398d916264d.jpg&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Simon Korzun",
+            "url": "http://korzun.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fa5bb532babae931bc81f78202d46ac9f%3Fdefault%3D404&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Mikko Piuhola",
+            "url": null,
+            "image": null,
+            "monthlyDonation": 500,
+            "totalDonations": 500
+        },
+        {
+            "name": "Dan Foley",
+            "url": "http://cantremember.com",
+            "image": null,
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Maisonette Inc",
+            "url": "https://www.maisonette.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fmaisonette.com&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 1000
+        },
+        {
+            "name": "Pawel Grzybek",
+            "url": "https://pawelgrzybek.com/",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Fc8bd1650-2f5d-11e9-9004-2b850be986d3.jpg&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 1000
         },
         {
             "name": "Martin K.",
             "url": "https://kluska.cz",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fd24fd0f59e722427d9db1b7f9699857c%3Fdefault%3D404&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 1000
         },
         {
-            "name": "Brie Bunge",
-            "url": null,
-            "image": null,
-            "totalDonations": 1000
+            "name": "Eric Lanehart",
+            "url": "http://pushred.co",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fpushred.co&height=96",
+            "monthlyDonation": 500,
+            "totalDonations": 500
         },
         {
             "name": "Third Iron",
             "url": "https://thirdiron.com",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F352bb130-32eb-11e9-9423-e9873eff8639.png&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 1000
         },
         {
             "name": "Deepak Jayaram",
             "url": null,
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fe43c688b523d6822aafaab1545be2565%3Fdefault%3D404&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 500
         },
         {
             "name": "Andrew Rota",
             "url": "https://twitter.com/andrewrota",
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F9d49f4a608c14193bd954892efa50b54_ca9c0d80-99d4-11e6-8650-f92e594d5de8.jpeg&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 500
         },
         {
             "name": "Will McAuliff",
             "url": null,
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fwww.gravatar.com%2Favatar%2Fe275c5b848e4b9a1d340acfeb2c51934%3Fdefault%3D404&height=96",
-            "totalDonations": 500
-        },
-        {
-            "name": "AJ Klein",
-            "url": "https://twitter.com/jumbleofideas",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F6c5aac30-3b68-11e9-9537-ad85092287b8.jpg&height=96",
-            "totalDonations": 500
-        },
-        {
-            "name": "Mikko Piuhola",
-            "url": null,
-            "image": null,
-            "totalDonations": 500
-        },
-        {
-            "name": "Eric Lanehart",
-            "url": "http://pushred.co",
-            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Flogo.clearbit.com%2Fpushred.co&height=96",
+            "monthlyDonation": 500,
             "totalDonations": 500
         },
         {
             "name": "Ramnik Sodhi",
             "url": null,
             "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fd1ts43dypk8bqh.cloudfront.net%2Fv1%2Favatars%2Fc20cca8b-dfdc-4351-b057-0a4ee26ba1a5&height=96",
+            "monthlyDonation": 200,
             "totalDonations": 200
+        },
+        {
+            "name": "Frontend Masters",
+            "url": "https://FrontendMasters.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F5e18b6b0-83b4-11e8-97c9-03259cc8bf2b.png&height=96",
+            "monthlyDonation": 0,
+            "totalDonations": 20000
+        },
+        {
+            "name": "Open Collective Inc.",
+            "url": "https://opencollective.com",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F8aa714c0-79fa-11e7-9a37-35a8ed456d67.png&height=96",
+            "monthlyDonation": 0,
+            "totalDonations": 1600
+        },
+        {
+            "name": "Triplebyte",
+            "url": "https://triplebyte.com/os/opencollective",
+            "image": "https://images.opencollective.com/proxy/images/?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2F02f87560-b2f1-11e8-85a0-75f200a0e2db.png&height=96",
+            "monthlyDonation": 0,
+            "totalDonations": 6000
         }
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -362,7 +362,6 @@
       "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -594,7 +593,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -631,7 +630,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -840,7 +839,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -886,7 +884,7 @@
     },
     "convert-source-map": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
       "dev": true
     },
@@ -908,7 +906,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -921,7 +919,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -1046,8 +1044,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "deps-sort": {
       "version": "2.0.0",
@@ -1084,7 +1081,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -1458,8 +1455,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -1723,12 +1719,11 @@
       "version": "2.16.3",
       "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
@@ -1986,8 +1981,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "json-loader": {
       "version": "0.5.7",
@@ -2214,15 +2208,13 @@
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
       "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.21",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -2256,7 +2248,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -2299,6 +2291,11 @@
         "through2": "^2.0.0",
         "xtend": "^4.0.0"
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "ms": {
       "version": "2.1.1",
@@ -2952,7 +2949,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -2962,7 +2959,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
@@ -3276,8 +3273,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "url": "https://github.com/eslint/eslint.github.io/issues"
   },
   "homepage": "https://github.com/eslint/eslint.github.io#readme",
-  "dependencies": {},
+  "dependencies": {
+    "moment": "^2.24.0"
+  },
   "devDependencies": {
     "@octokit/rest": "^16.16.0",
     "bootstrap": "^3.4.1",


### PR DESCRIPTION
Feedback from some sponsors is that they'd prefer sponsor logos be sorted by monthly donation amount (right now, it's basically sorted by when they made their first donation).

This PR updates the script to fetch sponsor data to include calculated monthly amounts and then sorts the data by that value.