### PR TITLE
Chore: change gems to plugins in _config.yml (fixes #563)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ exclude: [
 description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
 url: https://eslint.org
 permalink: /blog/:year/:month/:title
-gems:
+plugins:
     - jekyll-sitemap
     - jekyll-redirect-from
 kramdown:

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: "ESLint - Pluggable JavaScript linter"
+title: "ESLint - Pluggable JavaScript linter"
 repository: "eslint/eslint.github.io"
 exclude: [
   'node_modules',


### PR DESCRIPTION
The following warnings are printed out when we run `npm start`:
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.

GitHub Metadata: site.name is set in _config.yml, but many plugins and themes expect site.title to be used instead. To avoid potential inconsistency, Jekyll GitHub Metadata will not set site.title to the repository's name.
```

Small change to update _config.yml to use `plugins` instead of `gems`. Please see https://github.com/jekyll/jekyll/pull/5130 for more details. Also changed `site.name` to `site.title` in `_config.yml`.