### PR TITLE
Fix: syntax error in 2.0.0 valid-jsdoc (fixes #579)

### DIFF
--- a/docs/2.0.0/rules/valid-jsdoc.md
+++ b/docs/2.0.0/rules/valid-jsdoc.md
@@ -221,6 +221,7 @@ In the example below, it will expect the "object" to start with an uppercase and
 
 The following patterns are considered problems with option `preferType` setup as above:
 
+{% raw %}
 ```js
 /**
  * Adds two numbers together.
@@ -250,9 +251,11 @@ function foo(param1) {
     return {a: param1};
 }
 ```
+{% endraw %}
 
 The following patterns are not considered problems with option `preferType` setup as above:
 
+{% raw %}
 ```js
 /**
  * Adds two numbers together.
@@ -282,6 +285,7 @@ function foo(param1) {
     return {a: param1};
 }
 ```
+{% endraw %}
 
 ## When Not To Use It
 


### PR DESCRIPTION
fixes https://github.com/eslint/eslint.github.io/issues/579

There's currently a Liquid syntax error in `docs/2.0.0/rules/valid-jsoc` that results in some text in the JSDoc block not rendering. This is caused by the use of double curly brackets in the comment (which Liquid is trying and failing to parse as a tag). I haven't found a way to escape them, but according to [this StackOverflow question](https://stackoverflow.com/questions/24102498/escaping-double-curly-braces-inside-a-markdown-code-block-in-jekyll), it looks like the recommended way to solve this is just to treat it as raw text.

We weren't catching this in local dev because this directory is excluded from the generated site (I'm assuming to speed up incremental build time): https://github.com/eslint/eslint.github.io/blob/master/_config.dev.yml#L23. And since it only outputs a warning and doesn't fail the build, we weren't catching it in master.

Please note that CI is failing because I turned Travis CI on to test https://github.com/eslint/eslint.github.io/pull/578 and this will pass once that is merged (or we turn it off for PRs again).