### PR TITLE
Fix: Demo now uses updated Linter access point (fixes eslint/eslint#11873)

### DIFF
--- a/js/app/demo/app.jsx
+++ b/js/app/demo/app.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configuration", "eslint", "unicode"], function(React, Editor, Messages, FixedCode, Configuration, Linter, Unicode) {
+define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configuration", "eslint", "unicode"], function(React, Editor, Messages, FixedCode, Configuration, linterModule, Unicode) {
     var hasLocalStorage = (function() {
         try {
             window.localStorage.setItem("localStorageTest", "foo");
@@ -11,7 +11,7 @@ define(["react", "jsx!editor", "jsx!messages", "jsx!fixedCode", "jsx!configurati
         }
     }());
 
-    var linter = new Linter();
+    var linter = new linterModule.Linter();
     var rules = linter.getRules();
     var ruleNames = Array.from(rules.keys());
     var docs = (function() {


### PR DESCRIPTION
This commit just fixes the access point to get the demo working. Might not be the best long-term approach.

I'm also exploring (separate from this PR) whether it might be possible to add some unit tests to at least test that the React component can be generated.