### PR TITLE
Fix: fix site name in title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: "ESLint - Pluggable JavaScript linter"
+title: "ESLint - Pluggable JavaScript linter"
 repository: "eslint/eslint.github.io"
 exclude: [
   'node_modules',

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: "ESLint - Pluggable JavaScript linter"
+name: "ESLint - Pluggable JavaScript linter"
 repository: "eslint/eslint.github.io"
 exclude: [
   'node_modules',

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,7 +8,7 @@
   <meta name="description" content="{{ site.description }}">
   <meta name="theme-color" content="#463fd4"/>
   <meta property="og:locale" content="en_US">
-  <meta property="og:site_name" content="{{ site.name }}">
+  <meta property="og:site_name" content="{{ site.title }}">
   <meta property="og:title" content="{{ page.title }}">
   <meta property="og:url" content="{{ site.url }}{{ page.url }}">
   <meta property="og:image" content="{{ site.url }}/img/favicon.512x512.png">
@@ -19,21 +19,21 @@
   <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="{{ site.url }}/img/favicon.512x512.png">
-{% if page.title != site.name %}
+{% if page.title != site.title %}
     {% if page.title != "ESLint" %}
-        <title>{{ page.title }} - {{ site.name }}</title>
+        <title>{{ page.title }} - {{ site.title }}</title>
     {% else %}
-        <title>{{ site.name }}</title>
+        <title>{{ site.title }}</title>
     {% endif %}
 {% else %}
-  <title>{{ site.name }}</title>
+  <title>{{ site.title }}</title>
 {% endif %}
   <link rel="preconnect" href="https://www.google-analytics.com">
   <link href="{{ site.url }}{{ page.url }}" rel="canonical" />
   <link rel="stylesheet" href="{{ site.url }}/styles/main.css"/>
   <link rel='manifest' href='{{ site.url }}/manifest.json'>
   <link rel="icon" href="{{ site.url }}/img/favicon.512x512.png">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="{{ site.url }}/feed.xml">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url }}/feed.xml">
   <!-- at the end of the HEAD -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 </head>

--- a/feed.xml
+++ b/feed.xml
@@ -4,7 +4,7 @@ layout: null
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>{{ site.name | xml_escape }}</title>
+    <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/feed.xml" rel="self" type="application/rss+xml" />


### PR DESCRIPTION
The site name is missing at `<title>` of the pages, and this PR fixes it.

Page template: https://github.com/eslint/eslint.github.io/blob/26276d3554706862f6a280f20063ab7e74108b81/_includes/header.html#L24