### PR TITLE
Chore: Add Netlify status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/eslint/eslint.github.io.svg?branch=master)](https://travis-ci.org/eslint/eslint.github.io)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/cefb59aa-729a-4f8e-be36-b981fda399c0/deploy-status)](https://app.netlify.com/sites/eslint/deploys)
 
 # ESLint Web Site
 


### PR DESCRIPTION
This is provided by Netlify and shows the status of the last build in the README.