### PR TITLE
Enhancement: add Netlify badge to sponsors list

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,12 @@ homepage: true
         <p class="text-center"><a class="btn btn-default" href="https://opencollective.com/eslint">Become a Sponsor</a></p>
         {% endif %}
     {% endfor %}
+    <h3 class="text-center">Hosting</h3>
+    <div class="sponsors text-center">
+        <a href="https://www.netlify.com" rel="noopener nofollow" target="_blank">
+            <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"/>
+        </a>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
In exchange for the services they are providing to our project, Netlify asks that we link to their homepage from ours. Here is their full [Open Source Plan Policy](https://www.netlify.com/legal/open-source-policy/).

This PR adds a "Hosting" section to our list of sponsors with a link to https://www.netlify.com.

I would love to clean this section of the site up (and we will, when we get to the redesign!), but I think this makes the most sense for now. Please let me know if you disagree.