### PR TITLE
Fix: add Jekyll plugin to fix deployment preview URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ exclude: [
   'vendor'
 ]
 description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
-url: https://eslint.org
 permalink: /blog/:year/:month/:title
 plugins:
     - jekyll-sitemap

--- a/_plugins/config_url.rb
+++ b/_plugins/config_url.rb
@@ -1,10 +1,14 @@
-PRODUCTION_URL = 'https://eslint.org'
-DEPLOYMENT_PREVIEW_URL = ENV['DEPLOY_PRIME_URL']
+# Netlify sets the following environment variables
+# https://www.netlify.com/docs/continuous-deployment/#environment-variables
+DEPLOY_URL = (ENV['CONTEXT'].eql? 'production') ? ENV['URL'] : ENV['DEPLOY_PRIME_URL']
+
+# This is for backwards compatibility for the version currently deployed with GitHub Pages
+DEFAULT_URL = 'https://eslint.org'
 
 module Jekyll
     class EnvironmentVariablesGenerator < Generator
         def generate(site)
-            site.config['url'] = DEPLOYMENT_PREVIEW_URL || PRODUCTION_URL
+            site.config['url'] = DEPLOY_URL || DEFAULT_URL
         end
     end
 end

--- a/_plugins/config_url.rb
+++ b/_plugins/config_url.rb
@@ -1,0 +1,10 @@
+PRODUCTION_URL = 'https://eslint.org'
+DEPLOYMENT_PREVIEW_URL = ENV['DEPLOY_PRIME_URL']
+
+module Jekyll
+    class EnvironmentVariablesGenerator < Generator
+        def generate(site)
+            site.config['url'] = DEPLOYMENT_PREVIEW_URL || PRODUCTION_URL
+        end
+    end
+end


### PR DESCRIPTION
Currently, deployment preview builds are broken because we use `{{ site.url }}` in our Liquid templates to generate URLs. According to the [Netlify docs](https://www.netlify.com/docs/continuous-deployment/#environment-variables), it looks like the deployment preview URL should be set to this environment variable.

Please look over my Ruby - I'm not particularly familiar with the language :)