### PR TITLE
Consolidate pages in _pages directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Once you have setup a local environment, you can run a copy of the website local
 $ npm start
 ```
 
+To run webpack to bundle the JavaScript and styles, you can run the following:
+
+```
+$ npm run start:webpack
+```
+
 ## License
 
 MIT

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,12 @@
 title: "ESLint - Pluggable JavaScript linter"
 repository: "eslint/eslint.github.io"
+description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
+include:
+  - _pages
 exclude:
   - node_modules
   - src
   - vendor
-description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
 permalink: /blog/:year/:month/:title
 plugins:
     - jekyll-sitemap

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,6 +1,8 @@
 ---
 title: 404
 layout: doc
+permalink: /404.html
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/404.md
 ---
 
 # 4![0](/assets/img/logo.svg)4

--- a/_pages/blog.html
+++ b/_pages/blog.html
@@ -1,6 +1,8 @@
 ---
 title: ESLint Blog
 layout: post
+permalink: /blog
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/blog.html
 ---
 <br/>
 <ul class="posts">

--- a/_pages/cla.md
+++ b/_pages/cla.md
@@ -2,4 +2,6 @@
 title: ESLint Contributor License Agreement
 layout: doc
 redirect_to: "https://cla.js.foundation/eslint/eslint"
+permalink: /cla
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/cla.md
 ---

--- a/_pages/demo.html
+++ b/_pages/demo.html
@@ -1,7 +1,8 @@
 ---
 title: ESLint Demo
 layout: demo
-demopage: true
+permalink: /demo
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/demo.html
 ---
 <div id="app">
     <div class="loading-demo-message">

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -2,6 +2,7 @@
 title: ESLint - Pluggable JavaScript linter
 layout: default
 redirect_from: "/docs/"
+permalink: /index.html
 homepage: true
 ---
 

--- a/_pages/parser.html
+++ b/_pages/parser.html
@@ -1,6 +1,8 @@
 ---
 title: ESLint Parser Demo
 layout: demo
+permalink: /parser
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/parser.html
 ---
 <div class="row">
     <div class="col-md-6 parserPanel">

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -1,7 +1,8 @@
 ---
 title: Team
 layout: doc
-edit_link: https://github.com/eslint/eslint.github.io/edit/master/team/index.md
+permalink: /team
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/team.md
 ---
 
 # Team

--- a/_pages/users.md
+++ b/_pages/users.md
@@ -1,7 +1,8 @@
 ---
 title: "Who's Using ESLint?"
 layout: doc
-edit_link: https://github.com/eslint/eslint.github.io/edit/master/users/index.md
+permalink: /users
+edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/users.md
 ---
 
 # Who's Using ESLint?

--- a/docs/developer-guide/architecture/index.md
+++ b/docs/developer-guide/architecture/index.md
@@ -8,7 +8,7 @@ edit_link: https://github.com/eslint/eslint/edit/master/docs/developer-guide/arc
 
 # Architecture
 
-<center><img alt="dependency graph" src="./architecture/dependency.svg"></center>
+<center><img alt="dependency graph" src="./dependency.svg"></center>
 
 At a high level, there are a few key parts to ESLint:
 


### PR DESCRIPTION
This consolidates all the pages we have into a new `_pages` directory, cleaning up the root directory considerably :tada::
<img width="297" alt="Screen Shot 2019-07-12 at 12 51 25 AM" src="https://user-images.githubusercontent.com/7041728/61103250-3aecc080-a43f-11e9-8fcb-94b6ed7dfe90.png">


As I was working on this, I noticed that redirects are no longer working (which might be a result of moving off of GitHub Pages). For example, see https://eslint.org/docs/ or https://eslint.org/cla/. This PR doesn't fix this - I'll do that in a follow up PR. We should be able to use Netlify for redirects instead, as described [here](https://www.netlify.com/docs/redirects/).