### PR TITLE
Chore: use preset-env useBuiltIns option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,8 @@
     "presets": [
       "@babel/preset-react",
       ["@babel/preset-env", {
+        "useBuiltIns": "entry",
+        "corejs": 3,
         "modules": false,
         "targets": {
           "browsers": ["last 3 versions"]

--- a/src/js/demo/index.js
+++ b/src/js/demo/index.js
@@ -1,3 +1,6 @@
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./app";

--- a/src/js/main/index.js
+++ b/src/js/main/index.js
@@ -1,3 +1,6 @@
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+
 import docsearch from "docsearch.js";
 import AnchorJS from "anchor-js";
 import ImageObserver from "./image-lazy-loader";

--- a/src/js/parser/index.js
+++ b/src/js/parser/index.js
@@ -1,3 +1,6 @@
+import "core-js/stable";
+import "regenerator-runtime/runtime";
+
 import config from "./parser.config";
 import lib from "./lib";
 import "../../styles/parser.less";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,9 @@ const CleanCSSPlugin = require("less-plugin-clean-css");
 
 module.exports = {
     entry: {
-        demo: ["core-js/stable", "regenerator-runtime/runtime", path.join(__dirname, "src/js/demo/index.js")],
-        parser: ["core-js/stable", "regenerator-runtime/runtime", path.join(__dirname, "src/js/parser/index.js")],
-        main: ["core-js/stable", "regenerator-runtime/runtime", path.join(__dirname, "src/js/main/index.js")]
+        demo: path.join(__dirname, "src/js/demo/index.js"),
+        parser: path.join(__dirname, "src/js/parser/index.js"),
+        main: path.join(__dirname, "src/js/main/index.js")
     },
     output: {
         path: path.join(__dirname, "assets/build/js"),


### PR DESCRIPTION
I think this is what we want to do for now - Babel should rewrite 

```js
import "core-js/stable";
import "regenerator-runtime/runtime";
```

to the individual polyfills the environments we have specified need. It would be nice to split out a common chunks bundle in the future.

I believe we're only using the bundles found [here](https://github.com/eslint/eslint/blob/master/webpack.config.js#L6-L7) for the site (please correct me if I'm wrong!), so we should be able to remove `core-js/stable` and `regenerator-runtime/runtime` from those bundles when the site is generated.