### PR TITLE
Update: add margin to sponsors rows

### DIFF
--- a/src/styles/lib/sponsors.less
+++ b/src/styles/lib/sponsors.less
@@ -1,5 +1,6 @@
 .sponsors {
-    
+    margin-bottom: 12px;
+
     .gold-sponsor {
         height: 96px;
     }


### PR DESCRIPTION
This adds some spacing below the sponsors rows.

Before:
<img width="693" alt="Screen Shot 2019-07-12 at 1 33 44 AM" src="https://user-images.githubusercontent.com/7041728/61104637-1d225a00-a445-11e9-8f16-6c506fdd5bdf.png">

After:
<img width="765" alt="Screen Shot 2019-07-12 at 1 34 33 AM" src="https://user-images.githubusercontent.com/7041728/61104671-388d6500-a445-11e9-9cb7-cbeef09e338d.png">