### PR TITLE
Chore: import bootstrap.native components in bundles

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,8 +16,6 @@
         </ul>
       </footer>
     </div>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap.native/2.0.15/bootstrap-native.min.js" defer></script>
     <script src="{{ site.url }}/assets/build/js/main.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,6 +1549,11 @@
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
       "dev": true
     },
+    "bootstrap.native": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/bootstrap.native/-/bootstrap.native-2.0.26.tgz",
+      "integrity": "sha512-m1W61Mt3Y3pu6SU24sg5mZ0nHpxpBCVHVGyJGvEuWPjC/9+gpVvv0EEmbKOoLgZ6XU50QLqvNsh4SiKsjVnJTg=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/eslint/eslint.github.io#readme",
   "dependencies": {
     "anchor-js": "^4.2.0",
+    "bootstrap.native": "^2.0.26",
     "codemirror": "^5.48.0",
     "docsearch.js": "^2.6.3",
     "react": "^15.0.1",

--- a/src/js/demo/configuration.jsx
+++ b/src/js/demo/configuration.jsx
@@ -1,6 +1,5 @@
-/* global Popover */
-
 import React from "react";
+import { Popover } from "bootstrap.native";
 import ParserOptions from "./parserOptions";
 import Environments from "./environments";
 import RulesConfig from "./rulesConfig";


### PR DESCRIPTION
This fixes a console error that can be seen when clicking on the "Fixed Code" tab in the demo:
<img width="671" alt="Screen Shot 2019-07-12 at 2 13 12 AM" src="https://user-images.githubusercontent.com/7041728/61106714-f4519300-a44b-11e9-9330-c9dfb7f7c40b.png">

It also theoretically allows us to take advantage of Webpack's tree shaking, since it looks like we're only using this one component.