### PR TITLE
Revert "Chore: import bootstrap.native components in bundles (#600)"

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,6 +16,8 @@
         </ul>
       </footer>
     </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap.native/2.0.15/bootstrap-native.min.js" defer></script>
     <script src="{{ site.url }}/assets/build/js/main.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1549,11 +1549,6 @@
       "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
       "dev": true
     },
-    "bootstrap.native": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/bootstrap.native/-/bootstrap.native-2.0.26.tgz",
-      "integrity": "sha512-m1W61Mt3Y3pu6SU24sg5mZ0nHpxpBCVHVGyJGvEuWPjC/9+gpVvv0EEmbKOoLgZ6XU50QLqvNsh4SiKsjVnJTg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/eslint/eslint.github.io#readme",
   "dependencies": {
     "anchor-js": "^4.2.0",
-    "bootstrap.native": "^2.0.26",
     "codemirror": "^5.48.0",
     "docsearch.js": "^2.6.3",
     "react": "^15.0.1",

--- a/src/js/demo/configuration.jsx
+++ b/src/js/demo/configuration.jsx
@@ -1,5 +1,6 @@
+/* global Popover */
+
 import React from "react";
-import { Popover } from "bootstrap.native";
 import ParserOptions from "./parserOptions";
 import Environments from "./environments";
 import RulesConfig from "./rulesConfig";


### PR DESCRIPTION
This reverts commit d062cf33164238edceb01c0938bb9a005425f447.

Sorry everyone - I missed a few other bootstrap components we're using. Will revert this so that the site works correctly while I fix up the rest of the site.