### PR TITLE
Fix: set up Netlify redirect rules

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@ exclude:
 permalink: /blog/:year/:month/:title
 plugins:
     - jekyll-sitemap
-    - jekyll-redirect-from
 kramdown:
   input: GFM
   toc_levels: 2..3

--- a/_pages/cla.md
+++ b/_pages/cla.md
@@ -1,7 +1,6 @@
 ---
 title: ESLint Contributor License Agreement
-layout: doc
-redirect_to: "https://cla.js.foundation/eslint/eslint"
+layout: redirect
 permalink: /cla
 edit_link: https://github.com/eslint/eslint.github.io/edit/master/_pages/cla.md
 ---

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -1,7 +1,6 @@
 ---
 title: ESLint - Pluggable JavaScript linter
 layout: default
-redirect_from: "/docs/"
 permalink: /index.html
 homepage: true
 ---

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,36 @@
+# Netlify Redirect Rules
+# https://www.netlify.com/docs/redirects/
+
+# Redirect default Netlify subdomain to primary domain
+https://eslint.netlify.com/* https://eslint.org/:splat 301!
+
+/docs                               /
+/docs/user-guide/rules              /docs/rules
+/cla                                https://cla.js.foundation/eslint/eslint
+
+/docs/0.24.1/command-line-interface /docs/user-guide/command-line-interface
+/docs/0.24.1/configuring            /docs/user-guide/configuring
+/docs/0.24.1/integrations           /docs/integrations
+/docs/0.24.1/user-guide/rules       /docs/rules
+
+/docs/1.0.0/command-line-interface  /docs/user-guide/command-line-interface
+/docs/1.0.0/configuring             /docs/user-guide/configuring
+/docs/1.0.0/integrations            /docs/integrations
+/docs/1.0.0/user-guide/rules        /docs/rules
+
+/docs/1.10.3/command-line-interface /docs/user-guide/command-line-interface
+/docs/1.10.3/configuring            /docs/user-guide/configuring
+/docs/1.10.3/integrations           /docs/integrations
+/docs/1.10.3/user-guide/rules       /docs/rules
+
+/docs/2.0.0/command-line-interface  /docs/user-guide/command-line-interface
+/docs/2.0.0/configuring             /docs/user-guide/configuring
+/docs/2.0.0/integrations            /docs/integrations
+/docs/2.0.0/user-guide/rules        /docs/rules
+
+/docs/2.13.1/command-line-interface /docs/user-guide/command-line-interface
+/docs/2.13.1/configuring            /docs/user-guide/configuring
+/docs/2.13.1/integrations           /docs/integrations
+/docs/2.13.1/user-guide/rules       /docs/rules
+
+/docs/3.0.0/user-guide/rules        /docs/rules

--- a/docs/0.24.1/command-line-interface/index.html
+++ b/docs/0.24.1/command-line-interface/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
 ---
-

--- a/docs/0.24.1/configuring/index.html
+++ b/docs/0.24.1/configuring/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
 ---
-

--- a/docs/0.24.1/user-guide/integrations.md
+++ b/docs/0.24.1/user-guide/integrations.md
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 layout: doc
-redirect_from: "/docs/integrations/"
 ---
 
 # Integrations
@@ -30,7 +29,7 @@ redirect_from: "/docs/integrations/"
 * **Broccoli:**
     * [broccoli-eslint](https://www.npmjs.org/package/broccoli-eslint)
 * **Webpack:**
-    * [eslint-loader](https://www.npmjs.org/package/eslint-loader) 
+    * [eslint-loader](https://www.npmjs.org/package/eslint-loader)
 * **Ember-cli**
     * [ember-cli-eslint](https://www.npmjs.com/package/ember-cli-eslint)
 * **Sails.js**

--- a/docs/0.24.1/user-guide/rules.md
+++ b/docs/0.24.1/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/1.0.0/command-line-interface/index.html
+++ b/docs/1.0.0/command-line-interface/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
 ---
-

--- a/docs/1.0.0/configuring/index.html
+++ b/docs/1.0.0/configuring/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
 ---
-

--- a/docs/1.0.0/user-guide/integrations.md
+++ b/docs/1.0.0/user-guide/integrations.md
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 layout: doc
-redirect_from: "/docs/integrations/"
 ---
 
 # Integrations
@@ -30,7 +29,7 @@ redirect_from: "/docs/integrations/"
 * **Broccoli:**
     * [broccoli-eslint](https://www.npmjs.org/package/broccoli-eslint)
 * **Webpack:**
-    * [eslint-loader](https://www.npmjs.org/package/eslint-loader) 
+    * [eslint-loader](https://www.npmjs.org/package/eslint-loader)
 * **Ember-cli**
     * [ember-cli-eslint](https://www.npmjs.com/package/ember-cli-eslint)
 * **Sails.js**

--- a/docs/1.0.0/user-guide/rules.md
+++ b/docs/1.0.0/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/1.10.3/command-line-interface/index.html
+++ b/docs/1.10.3/command-line-interface/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
 ---
-

--- a/docs/1.10.3/configuring/index.html
+++ b/docs/1.10.3/configuring/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
 ---
-

--- a/docs/1.10.3/user-guide/integrations.md
+++ b/docs/1.10.3/user-guide/integrations.md
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 layout: doc
-redirect_from: "/docs/integrations/"
 ---
 
 # Integrations

--- a/docs/1.10.3/user-guide/rules.md
+++ b/docs/1.10.3/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/2.0.0/command-line-interface/index.html
+++ b/docs/2.0.0/command-line-interface/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
 ---
-

--- a/docs/2.0.0/configuring/index.html
+++ b/docs/2.0.0/configuring/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
 ---
-

--- a/docs/2.0.0/user-guide/integrations.md
+++ b/docs/2.0.0/user-guide/integrations.md
@@ -1,7 +1,6 @@
 ---
 title: Integrations
 layout: doc
-redirect_from: "/docs/integrations/"
 ---
 
 # Integrations

--- a/docs/2.0.0/user-guide/rules.md
+++ b/docs/2.0.0/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/2.13.1/command-line-interface/index.html
+++ b/docs/2.13.1/command-line-interface/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/command-line-interface"
 ---
-

--- a/docs/2.13.1/configuring/index.html
+++ b/docs/2.13.1/configuring/index.html
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/user-guide/configuring"
 ---
-

--- a/docs/2.13.1/user-guide/rules.md
+++ b/docs/2.13.1/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/3.0.0/user-guide/rules.md
+++ b/docs/3.0.0/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-

--- a/docs/user-guide/rules.md
+++ b/docs/user-guide/rules.md
@@ -1,6 +1,4 @@
 ---
 layout: redirect
 sitemap: false
-redirect_to:  "/docs/rules/"
 ---
-


### PR DESCRIPTION
Redirects are currently broken. This PR sets up redirect rules for Netlify (see docs [here](https://www.netlify.com/docs/redirects/)).

Would love if someone who has some more historical context around these redirects could look these over!