### PR TITLE
Fix: update files copied into _site

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-eslint.org

--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -9,13 +9,16 @@ future: true
 
 # Don't generate this stuff
 exclude:
-  - README.md
-  - CNAME
-  - Gemfile
-  - Gemfile.lock
-  - package.json
   - node_modules
   - src
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - Makefile
+  - package-lock.json
+  - package.json
+  - README.md
+  - webpack.config.js
   - sitemap.xml
   - feed.xml
   - docs/0.24.1

--- a/_config.yml
+++ b/_config.yml
@@ -2,11 +2,20 @@ title: "ESLint - Pluggable JavaScript linter"
 repository: "eslint/eslint.github.io"
 description: "A pluggable and configurable linter tool for identifying and reporting on patterns in JavaScript. Maintain your code quality with ease."
 include:
+  - _redirects
   - _pages
 exclude:
   - node_modules
   - src
   - vendor
+  - Gemfile
+  - Gemfile.lock
+  - LICENSE
+  - Makefile
+  - package-lock.json
+  - package.json
+  - README.md
+  - webpack.config.js
 permalink: /blog/:year/:month/:title
 plugins:
     - jekyll-sitemap


### PR DESCRIPTION
This PR does three things:
 - I didn't realize files that start with `_` are not included in the build, so `_redirects` isn't currently being included
 - We're serving a number of files that are copied (for examples, https://eslint.org/webpack.config.js). This should fix this. 
 - Removes the `CNAME` file that is only necessary for GitHub Pages.