### PR TITLE
Upgrade: update lodash in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4646,9 +4646,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash.get": {


### PR DESCRIPTION
Running `npm install` currently outputs the following: 
```
found 166 vulnerabilities (1 low, 165 high) in 7523 scanned packages
  run `npm audit fix` to fix 165 of them.
  1 vulnerability requires manual review. See the full report for details.
```

This PR updates the lockfile using `npm audit fix` using to fix 165 of these errors.